### PR TITLE
Read tracing header directly from xray

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,6 +2,7 @@ import http from "http";
 
 import { datadog } from "./index";
 
+// tslint:disable-next-line: no-var-requires
 const nock = require("nock");
 
 describe("datadog", () => {

--- a/src/trace/constants.ts
+++ b/src/trace/constants.ts
@@ -4,14 +4,10 @@ export enum SampleMode {
   AUTO_KEEP = 1,
   USER_KEEP = 2,
 }
-export const traceHeaderPrefix = "X-Amzn-Trace-Id:";
-export const traceIDTag = "Root";
-export const parentIDTag = "Parent";
-export const sampledTag = "Sampled";
+
 export const traceIDHeader = "x-datadog-trace-id";
 export const parentIDHeader = "x-datadog-parent-id";
 export const samplingPriorityHeader = "x-datadog-sampling-priority";
-export const traceEnvVar = "_X_AMZN_TRACE_ID";
 export const xraySubsegmentName = "datadog-metadata";
 export const xraySubsegmentKey = "trace";
 export const xraySubsegmentNamespace = "datadog";

--- a/types/aws-xray-sdk-core/index.d.ts
+++ b/types/aws-xray-sdk-core/index.d.ts
@@ -4,6 +4,7 @@ declare module "aws-xray-sdk-core" {
     trace_id: string;
     parent_id: string;
     id: string;
+    notTraced: boolean | undefined;
 
     constructor(name: string, rootId: string, parentId: string);
     addMetadata(key: string, value: object | null, namespace?: string): void;


### PR DESCRIPTION

<img width="997" alt="Screen Shot 2019-06-05 at 3 05 27 PM" src="https://user-images.githubusercontent.com/50632605/58982841-637bfd80-87a3-11e9-8f06-bfc70755efbe.png">
<img width="688" alt="Screen Shot 2019-06-05 at 3 01 26 PM" src="https://user-images.githubusercontent.com/50632605/58982722-18fa8100-87a3-11e9-9e93-2189bbac5d39.png">

### What does this PR do?

Fixes context to read xray trace header directly from xray sdk, rather than from environment variable. Also fixes the metadata added to xray to use the correct tags.

### Testing Guidelines

Run yarn test, or run ./scripts/run_tests.sh

