### PR TITLE
Cleans up socket after sending payload to x-ray

### DIFF
--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -19,6 +19,7 @@ import {
 } from "./context";
 
 let sentSegment: any;
+let closedSocket = false;
 
 jest.mock("dgram", () => {
   return {
@@ -27,6 +28,9 @@ jest.mock("dgram", () => {
         send: (message: string) => {
           sentSegment = message;
         },
+        close: () => {
+          closedSocket = true;
+        }
       };
     },
   };
@@ -39,6 +43,7 @@ jest.mock("crypto", () => {
 
 beforeEach(() => {
   sentSegment = undefined;
+  closedSocket = false;
   setLogLevel(LogLevel.NONE);
 });
 
@@ -424,6 +429,7 @@ describe("extractTraceContext", () => {
     });
 
     expect(sentSegment instanceof Buffer).toBeTruthy();
+    expect(closedSocket).toBeTruthy();
     const sentMessage = sentSegment.toString();
     expect(sentMessage).toMatchInlineSnapshot(`
       "{\\"format\\": \\"json\\", \\"version\\": 1}
@@ -469,6 +475,8 @@ describe("extractTraceContext", () => {
     extractTraceContext(stepFunctionEvent);
 
     expect(sentSegment instanceof Buffer).toBeTruthy();
+    expect(closedSocket).toBeTruthy();
+
     const sentMessage = sentSegment.toString();
     expect(sentMessage).toMatchInlineSnapshot(`
       "{\\"format\\": \\"json\\", \\"version\\": 1}

--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -30,7 +30,7 @@ jest.mock("dgram", () => {
         },
         close: () => {
           closedSocket = true;
-        }
+        },
       };
     },
   };

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "bignumber.js";
 import { randomBytes } from "crypto";
-import { createSocket } from "dgram";
+import { createSocket, Socket } from "dgram";
 
 import { logDebug, logError } from "../utils";
 import {
@@ -130,14 +130,19 @@ export function sendXraySubsegment(segment: string) {
   const address = parts[0];
 
   const message = new Buffer(`{\"format\": \"json\", \"version\": 1}\n${segment}`);
+  let client: Socket | undefined;
   try {
-    const client = createSocket("udp4");
+    client = createSocket("udp4");
     // Send segment asynchronously to xray daemon
     client.send(message, 0, message.length, port, address, (error, bytes) => {
       logDebug(`Xray daemon received metadata payload`, { error, bytes });
     });
   } catch (error) {
     logDebug("Error occurred submitting to xray daemon", { error });
+  }
+  finally {
+    // Cleanup socket
+    client?.close();
   }
 }
 

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -139,8 +139,7 @@ export function sendXraySubsegment(segment: string) {
     });
   } catch (error) {
     logDebug("Error occurred submitting to xray daemon", { error });
-  }
-  finally {
+  } finally {
     // Cleanup socket
     client?.close();
   }


### PR DESCRIPTION
### What does this PR do?

Socket for send X-Ray sdk payload wasn't being cleaned up correctly, and was causing system to run out of sockets.

### Motivation

Fix for issue #113 .

### Testing Guidelines

### Additional Notes

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
