### PR TITLE
Fix legacy issue with context.done callbacks

### DIFF
--- a/src/utils/handler.spec.ts
+++ b/src/utils/handler.spec.ts
@@ -233,4 +233,67 @@ describe("wrap", () => {
     expect(result).toEqual({ statusCode: 204, body: "The callback response" });
     expect(calledOriginalHandler).toBeFalsy();
   });
+
+  it("completes when calling context.done", async () => {
+    const handler: Handler = async (event, context, callback) => {
+      context.done(undefined, { statusCode: 204, body: "The callback response" });
+    };
+
+    let calledOriginalHandler = false;
+
+    const wrappedHandler = wrap(
+      handler,
+      async () => {},
+      async () => {},
+    );
+
+    const result = await wrappedHandler({}, mockContext, () => {
+      calledOriginalHandler = true;
+    });
+
+    expect(result).toEqual({ statusCode: 204, body: "The callback response" });
+    expect(calledOriginalHandler).toBeFalsy();
+  });
+  it("completes when calling context.succeed", async () => {
+    const handler: Handler = async (event, context, callback) => {
+      context.succeed({ statusCode: 204, body: "The callback response" });
+    };
+
+    let calledOriginalHandler = false;
+
+    const wrappedHandler = wrap(
+      handler,
+      async () => {},
+      async () => {},
+    );
+
+    const result = await wrappedHandler({}, mockContext, () => {
+      calledOriginalHandler = true;
+    });
+
+    expect(result).toEqual({ statusCode: 204, body: "The callback response" });
+    expect(calledOriginalHandler).toBeFalsy();
+  });
+
+  it("throws error when calling context.fail", async () => {
+    const handler: Handler = async (event, context, callback) => {
+      context.fail(new Error("Some error"));
+    };
+
+    let calledOriginalHandler = false;
+
+    const wrappedHandler = wrap(
+      handler,
+      async () => {},
+      async () => {},
+    );
+
+    const result = wrappedHandler({}, mockContext, () => {
+      calledOriginalHandler = true;
+    });
+
+    await expect(result).rejects.toEqual(new Error("Some error"));
+
+    expect(calledOriginalHandler).toBeFalsy();
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes issue where lambda wrapper was never completes, due to an undocumented/deprecated API for completing the invocation. [See here](https://stackoverflow.com/questions/54846513/lambda-trigger-callback-vs-context-done)

### Motivation

Because the wrapper was never completing, but the invocation was, trace spans would end up joined together in a mega trace.

### Testing Guidelines

I've added unit tests, and also tested this manually to verify the fix.

### Additional Notes

### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
