### PR TITLE
Fix bug with closing xray socket too early

### DIFF
--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -25,8 +25,16 @@ jest.mock("dgram", () => {
   return {
     createSocket: () => {
       return {
-        send: (message: string) => {
+        send: (
+          message: string,
+          start: number,
+          length: number,
+          port: number,
+          address: string,
+          callback: (error: string | undefined, bytes: number) => void,
+        ) => {
           sentSegment = message;
+          callback(undefined, 1);
         },
         close: () => {
           closedSocket = true;
@@ -475,6 +483,7 @@ describe("extractTraceContext", () => {
     extractTraceContext(stepFunctionEvent);
 
     expect(sentSegment instanceof Buffer).toBeTruthy();
+
     expect(closedSocket).toBeTruthy();
 
     const sentMessage = sentSegment.toString();

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -135,13 +135,11 @@ export function sendXraySubsegment(segment: string) {
     client = createSocket("udp4");
     // Send segment asynchronously to xray daemon
     client.send(message, 0, message.length, port, address, (error, bytes) => {
+      client?.close();
       logDebug(`Xray daemon received metadata payload`, { error, bytes });
     });
   } catch (error) {
     logDebug("Error occurred submitting to xray daemon", { error });
-  } finally {
-    // Cleanup socket
-    client?.close();
   }
 }
 

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -139,6 +139,7 @@ export function sendXraySubsegment(segment: string) {
       logDebug(`Xray daemon received metadata payload`, { error, bytes });
     });
   } catch (error) {
+    client?.close();
     logDebug("Error occurred submitting to xray daemon", { error });
   }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with the x-ray socket being closed too early. This causes metadata to not be submitted to x-ray.

### Motivation

Discovered while testing

### Testing Guidelines


### Additional Notes


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
