### PR TITLE
Fixes HTTP tag extraction for API Gateway v1 events

### DIFF
--- a/event_samples/api-gateway-v1.json
+++ b/event_samples/api-gateway-v1.json
@@ -1,0 +1,80 @@
+{
+  "version": "1.0",
+  "resource": "/my/path",
+  "path": "/my/path",
+  "httpMethod": "GET",
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "multiValueHeaders": {
+    "Header1": [
+      "value1"
+    ],
+    "Header2": [
+      "value1",
+      "value2"
+    ]
+  },
+  "queryStringParameters": {
+    "parameter1": "value1",
+    "parameter2": "value"
+  },
+  "multiValueQueryStringParameters": {
+    "parameter1": [
+      "value1",
+      "value2"
+    ],
+    "parameter2": [
+      "value"
+    ]
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "id",
+    "authorizer": {
+      "claims": null,
+      "scopes": null
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "extendedRequestId": "request-id",
+    "httpMethod": "GET",
+    "identity": {
+      "accessKey": null,
+      "accountId": null,
+      "caller": null,
+      "cognitoAuthenticationProvider": null,
+      "cognitoAuthenticationType": null,
+      "cognitoIdentityId": null,
+      "cognitoIdentityPoolId": null,
+      "principalOrgId": null,
+      "sourceIp": "IP",
+      "user": null,
+      "userAgent": "user-agent",
+      "userArn": null,
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "path": "/my/path",
+    "protocol": "HTTP/1.1",
+    "requestId": "id=",
+    "requestTime": "04/Mar/2020:19:15:17 +0000",
+    "requestTimeEpoch": 1583349317135,
+    "resourceId": null,
+    "resourcePath": "/my/path",
+    "stage": "$default"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "body": "Hello from Lambda!",
+  "isBase64Encoded": false
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "3.47.0",
+  "version": "3.48.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/trace/trigger.spec.ts
+++ b/src/trace/trigger.spec.ts
@@ -13,6 +13,16 @@ describe("parseEventSource", () => {
     {
       result: {
         "function_trigger.event_source": "api-gateway",
+        "function_trigger.event_source_arn": "arn:aws:apigateway:us-east-1::/restapis/id/stages/$default",
+        "http.url": "id.execute-api.us-east-1.amazonaws.com",
+        "http.url_details.path": "/my/path",
+        "http.method": "GET",
+      },
+      file: "api-gateway-v1.json",
+    },
+    {
+      result: {
+        "function_trigger.event_source": "api-gateway",
         "function_trigger.event_source_arn": "arn:aws:apigateway:us-east-1::/restapis/1234567890/stages/prod",
         "http.url": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
         "http.url_details.path": "/prod/path/to/resource",
@@ -136,7 +146,7 @@ describe("parseEventSource", () => {
       for (let response of responses) {
         const statusCode = extractHTTPStatusCodeTag(triggerTags, response.responseBody);
         // We should always return a status code for API Gateway and ALB
-        if (["api-gateway.json", "application-load-balancer.json"].includes(event.file)) {
+        if (["api-gateway-v1.json", "api-gateway.json", "application-load-balancer.json"].includes(event.file)) {
           expect(statusCode).toEqual(response.expectedStatusCode);
         } else {
           expect(statusCode).toBeUndefined();

--- a/src/trace/trigger.ts
+++ b/src/trace/trigger.ts
@@ -205,6 +205,7 @@ function extractHTTPTags(event: APIGatewayEvent | APIGatewayProxyEventV2 | ALBEv
     if (event.headers.Referer) {
       httpTags["http.referer"] = event.headers.Referer;
     }
+    return httpTags;
   }
 
   if (eventType.isAPIGatewayEventV2(event)) {
@@ -215,6 +216,7 @@ function extractHTTPTags(event: APIGatewayEvent | APIGatewayProxyEventV2 | ALBEv
     if (event.headers.Referer) {
       httpTags["http.referer"] = event.headers.Referer;
     }
+    return httpTags;
   }
 
   if (eventType.isALBEvent(event)) {
@@ -223,8 +225,8 @@ function extractHTTPTags(event: APIGatewayEvent | APIGatewayProxyEventV2 | ALBEv
     if (event.headers && event.headers.Referer) {
       httpTags["http.referer"] = event.headers.Referer;
     }
+    return httpTags;
   }
-  return httpTags;
 }
 
 /**
@@ -248,7 +250,11 @@ export function extractTriggerTags(event: any, context: Context) {
   }
 
   if (isHTTPTriggerEvent(eventSource)) {
-    triggerTags = { ...triggerTags, ...extractHTTPTags(event) };
+    try {
+      triggerTags = { ...triggerTags, ...extractHTTPTags(event) };
+    } catch (error) {
+      logError(`failed to extract http tags from ${eventSource} event`);
+    }
   }
   return triggerTags;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Makes `extractHTTPTags` return immediately after extracting HTTP tags from the trigger event. 

### Motivation

<!--- What inspired you to submit this pull request? --->
Fixes a bug where API Gateway V1 events were being parsed as V2, resulting in an uncaught exception. Reported by #162 

### Testing Guidelines

<!--- How did you test this pull request? --->
Added an API Gateway v1 sample request to the unit tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
