### PR TITLE
Fix use of deprecated Buffer constructor

### DIFF
--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -162,7 +162,7 @@ export function sendXraySubsegment(segment: string) {
   const port = parseInt(parts[1], 10);
   const address = parts[0];
 
-  const message = new Buffer(`{\"format\": \"json\", \"version\": 1}\n${segment}`);
+  const message = Buffer.from(`{\"format\": \"json\", \"version\": 1}\n${segment}`);
   let client: Socket | undefined;
   try {
     client = createSocket("udp4");


### PR DESCRIPTION
### What does this PR do?

Replaces deprecated buffer constructor use with Buffer.from method

### Motivation

Issue #168 

### Testing Guidelines



### Additional Notes



### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
