### PR TITLE
Improve layer publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,13 @@ RUN jq '. +{"dependencies": (.dependencies + {"dd-trace": .devDependencies."dd-t
 # Copy the production dependencies to the modules folder
 RUN yarn install --production=true
 RUN cp -rf node_modules/* /nodejs/node_modules
+
 # Remove the AWS SDK, which is installed in the lambda by default
 RUN rm -rf /nodejs/node_modules/aws-sdk
 RUN rm -rf /nodejs/node_modules/aws-xray-sdk-core/node_modules/aws-sdk
+
 # Remove heavy files from dd-trace which aren't used in a lambda environment
 RUN rm -rf /nodejs/node_modules/dd-trace/prebuilds
 RUN rm -rf /nodejs/node_modules/dd-trace/dist
+RUN rm -rf /nodejs/node_modules/hdr-histogram-js/build
+RUN rm -rf /nodejs/node_modules/protobufjs/dist

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -1,50 +1,91 @@
 #!/bin/bash
+
+# Use with `./publish_prod.sh <DESIRED_NEW_VERSION>
+
 set -e
 
+# Ensure on main, and pull the latest
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ $BRANCH != "main" ]; then
     echo "Not on main, aborting"
     exit 1
+else
+    echo "Updating main"
+    git pull origin main
 fi
 
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-    echo 'AWS_ACCESS_KEY_ID not set. Are you using aws-vault?'
+# Ensure no uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Detected uncommitted changes, aborting"
     exit 1
 fi
 
-if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-    echo 'AWS_SECRET_ACCESS_KEY not set. Are you using aws-vault?'
+# Read the new version
+if [ -z "$1" ]; then
+    echo "Must specify a desired version number"
     exit 1
+elif [[ ! $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Must use a semantic version, e.g., 3.1.4"
+    exit 1
+else
+    NEW_VERSION=$1
 fi
 
-if [ -z "$AWS_SESSION_TOKEN" ]; then
-    echo 'AWS_SESSION_TOKEN not set. Are you using aws-vault?'
-    exit 1
-fi
-
-echo 'Checking Regions'
-./scripts/list_layers.sh
-
+echo "Ensure you have access to the dataodg NPM service account"
 yarn login
 
-PACKAGE_VERSION=$(node -pe "require('./package.json').version")
+echo "Ensure you have access to the AWS GovCloud account"
+saml2aws login -a govcloud-us1-fed-human-engineering
+AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
 
-echo 'Publishing to Node'
-yarn build
-yarn publish --new-version "$PACKAGE_VERSION"
+echo "Ensure you have access to the commercial AWS GovCloud account"
+aws-vault exec prod-engineering -- aws sts get-caller-identity
 
-echo 'Tagging Release'
-git tag "v$PACKAGE_VERSION"
-git push origin "refs/tags/v$PACKAGE_VERSION"
+CURRENT_VERSION=$(npm view datadog-lambda-js version)
+LAYER_VERSION=$(echo $NEW_VERSION | cut -d '.' -f 2)
+
+read -p "Ready to update the library version from $CURRENT_VERSION to $NEW_VERSION and publish layer version $LAYER_VERSION (y/n)?" CONT
+if [ "$CONT" != "y" ]; then
+    echo "Exiting"
+    exit 1
+fi
+
+# Update the version without committing
+yarn version --no-git-tag-version --new-version $NEW_VERSION
 
 echo
 echo 'Building layers...'
 ./scripts/build_layers.sh
 
 echo
-echo "Signing layers..."
-./scripts/sign_layers.sh prod
+echo "Signing layers for commercial AWS regions"
+aws-vault exec prod-engineering -- ./scripts/sign_layers.sh prod
 
 echo
-echo "Publishing layers..."
-./scripts/publish_layers.sh
+echo "Publishing layers to commercial AWS regions"
+VERSION=$LAYER_VERSION aws-vault exec prod-engineering --no-session -- ./scripts/publish_layers.sh
+
+echo "Publishing layers to GovCloud AWS regions"
+saml2aws login -a govcloud-us1-fed-human-engineering
+VERSION=$LAYER_VERSION AWS_PROFILE=govcloud-us1-fed-human-engineering ./scripts/publish_layers.sh
+
+read -p "Ready to publish $NEW_VERSION to NPM (y/n)?" CONT
+if [ "$CONT" != "y" ]; then
+    echo "Exiting"
+    exit 1
+fi
+
+echo 'Publishing to NPM'
+yarn build
+yarn publish --new-version "$NEW_VERSION"
+
+echo
+echo 'Publishing updates to github'
+git commit package.json -m "Bump version to ${NEW_VERSION}"
+git push origin main
+git tag "v$NEW_VERSION"
+git push origin "refs/tags/v$NEW_VERSION"
+
+echo
+echo "Now create a new release with the tag v${NEW_VERSION} created"
+echo "https://github.com/DataDog/datadog-lambda-js/releases/new?tag=v$NEW_VERSION&title=v$NEW_VERSION"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Move the GovCloud layer publishing steps into the script
- Tie the layer publishing script to a specific version and safe for retry
- Strip out `hdr-histogram-js/build` and `protobufjs/dist` to reduce layer size

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
