### PR TITLE
Add null checks when checking for object types

### DIFF
--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -582,6 +582,15 @@ describe("extractTraceContext", () => {
       source: Source.Event,
     });
   });
+  it("returns an empty context when headers are null", () => {
+    const result = extractTraceContext(
+      {
+        headers: null,
+      },
+      {} as Context,
+    );
+    expect(result).toEqual(undefined);
+  });
   it("returns trace read from event with the extractor as the highest priority", () => {
     process.env["_X_AMZN_TRACE_ID"] = "Root=1-5ce31dc2-2c779014b90ce44db5e03875;Parent=0b11cc4230d3e09e;Sampled=1";
 

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -287,11 +287,11 @@ export function readTraceFromHTTPEvent(event: any): TraceContext | undefined {
 }
 
 export function readTraceFromEvent(event: any): TraceContext | undefined {
-  if (typeof event !== "object") {
+  if (!event || typeof event !== "object") {
     return;
   }
 
-  if (typeof event.headers === "object") {
+  if (event.headers !== null && typeof event.headers === "object") {
     return readTraceFromHTTPEvent(event);
   }
 

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -14,7 +14,7 @@ export interface HTTPError {
   statusCode?: number;
 }
 export function isHTTPError(error: any): error is HTTPError {
-  return typeof error === "object" && Object.values(HTTPErrorType).includes(error.type);
+  return typeof error === "object" && error !== null && Object.values(HTTPErrorType).includes(error.type);
 }
 
 export function post<T>(url: URL, body: T, options?: Partial<RequestOptions>): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

Fixes error that was caused by a null headers property on event payload, causing listeners to fail to initialize. Also addressed another potentially similar issue around http patching logic.

### Motivation

#174 

### Testing Guidelines

Added a unit test to verify issue+fix.

### Additional Notes



### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
