### PR TITLE
Fix bug where flushToLogs and the extension would cause timeouts

### DIFF
--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -1,9 +1,13 @@
 import { AWSError, KMS, Request } from "aws-sdk";
 import nock from "nock";
+import mock from "mock-fs";
 
 import { LogLevel, setLogLevel } from "../utils";
+import { AGENT_URL } from "./extension";
 
 import { MetricsListener } from "./listener";
+import StatsDClient from "hot-shots";
+jest.mock('hot-shots');
 
 const siteURL = "example.com";
 
@@ -95,6 +99,40 @@ describe("MetricsListener", () => {
     await listener.onCompleteInvocation();
 
     expect(spy).toHaveBeenCalledWith(`{"e":1487076708,"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
+  });
+  it("sends metrics to statsD when extension is enabled", async () => {
+    const helloScope = nock(AGENT_URL).get("/lambda/hello").reply(200);
+    const flushScope = nock(AGENT_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
+    mock({
+      "/opt/extensions/datadog-agent": Buffer.from([0]),
+    });
+    const distributionMock = jest.fn();
+    (StatsDClient as any).mockImplementation(() => {
+      return {
+        distribution: distributionMock,
+        close: (callback: any) => callback(undefined),
+      };
+    });
+
+    jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
+
+    const kms = new MockKMS("kms-api-key-decrypted");
+    const listener = new MetricsListener(kms as any, {
+      apiKey: "api-key",
+      apiKeyKMS: "",
+      enhancedMetrics: false,
+      logForwarding: true,
+      shouldRetryMetrics: false,
+      siteURL,
+    });
+    jest.useFakeTimers();
+
+    await listener.onStartInvocation({});
+    listener.sendDistributionMetric("my-metric", 10, false, "tag:a", "tag:b");
+    await listener.onCompleteInvocation();
+    expect(helloScope.isDone()).toBeTruthy();
+    expect(flushScope.isDone()).toBeTruthy();
+    expect(distributionMock).toHaveBeenCalledWith("my-metric", 10, undefined, ["tag:a", "tag:b"]);
   });
 
   it("logs metrics when logForwarding is enabled with custom timestamp", async () => {

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -7,7 +7,7 @@ import { AGENT_URL } from "./extension";
 
 import { MetricsListener } from "./listener";
 import StatsDClient from "hot-shots";
-jest.mock('hot-shots');
+jest.mock("hot-shots");
 
 const siteURL = "example.com";
 
@@ -100,7 +100,7 @@ describe("MetricsListener", () => {
 
     expect(spy).toHaveBeenCalledWith(`{"e":1487076708,"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
   });
-  it("sends metrics to statsD when extension is enabled", async () => {
+  it("always sends metrics to statsD when extension is enabled, ignoring logForwarding=true", async () => {
     const helloScope = nock(AGENT_URL).get("/lambda/hello").reply(200);
     const flushScope = nock(AGENT_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     mock({

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -65,15 +65,16 @@ export class MetricsListener {
       logDebug(`Extension present: ${this.isAgentRunning}`);
     }
 
-    if (this.config.logForwarding) {
-      logDebug(`logForwarding configured`);
 
-      return;
-    }
     if (this.isAgentRunning) {
       logDebug(`Using StatsD client`);
 
       this.statsDClient = new StatsD({ host: "127.0.0.1" });
+      return;
+    }
+    if (this.config.logForwarding) {
+      logDebug(`logForwarding configured`);
+
       return;
     }
     this.currentProcessor = this.createProcessor(this.config, this.apiKey);
@@ -105,14 +106,19 @@ export class MetricsListener {
           });
         });
         this.statsDClient = undefined;
-        logDebug(`Flushing Extension`);
-
-        await flushExtension();
       }
     } catch (error) {
       // This can fail for a variety of reasons, from the API not being reachable,
       // to KMS key decryption failing.
       logError(`failed to flush metrics`, { innerError: error });
+    }
+    try {
+      if (this.isAgentRunning) {
+        logDebug(`Flushing Extension`);
+        await flushExtension();
+      }
+    } catch (error) {
+      logError(`failed to flush extension`, { innerError: error });
     }
     this.currentProcessor = undefined;
   }

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -65,7 +65,6 @@ export class MetricsListener {
       logDebug(`Extension present: ${this.isAgentRunning}`);
     }
 
-
     if (this.isAgentRunning) {
       logDebug(`Using StatsD client`);
 


### PR DESCRIPTION
### What does this PR do?
Identified issue where extension isn't flushing when 'DD_FLUSH_TO_LOGS' is set to true. This modifies the flow to guarantee the extension is always flushed, and that DD_FLUSH_TO_LOGS is ignored when used with the extension.

### Motivation



### Testing Guidelines

Added a unit test, and tested manually.

### Additional Notes



### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
