### PR TITLE
Handle non-string logged content with trace ID injection

### DIFF
--- a/src/trace/patch-console.spec.ts
+++ b/src/trace/patch-console.spec.ts
@@ -82,6 +82,14 @@ describe("patchConsole", () => {
     cnsole.log();
     expect(log).toHaveBeenCalledWith("[dd.trace_id=123456 dd.span_id=78910]");
   });
+  it("injects trace context into logged object message", () => {
+    patchConsole(cnsole as any, contextService);
+
+    cnsole.log({ objectKey: "objectValue", otherObjectKey: "otherObjectValue" });
+    expect(log).toHaveBeenCalledWith(
+      "[dd.trace_id=123456 dd.span_id=78910] { objectKey: 'objectValue', otherObjectKey: 'otherObjectValue' }",
+    );
+  });
   it("leaves empty message unmodified when there is no trace context", () => {
     contextService.rootTraceContext = undefined;
     patchConsole(cnsole as any, contextService);

--- a/src/trace/patch-console.ts
+++ b/src/trace/patch-console.ts
@@ -1,4 +1,5 @@
 import * as shimmer from "shimmer";
+import { inspect } from "util";
 
 import { getLogLevel, LogLevel, setLogLevel } from "../utils/log";
 import { TraceContextService } from "./trace-context-service";
@@ -58,7 +59,14 @@ function patchMethod(mod: Console, method: LogMethod, contextService: TraceConte
             arguments.length = 1;
             arguments[0] = prefix;
           } else {
-            arguments[0] = `${prefix} ${arguments[0]}`;
+            let logContent = arguments[0];
+
+            // If what's being logged is not a string, use util.inspect to get a str representation
+            if (typeof logContent !== "string") {
+              logContent = inspect(logContent);
+            }
+
+            arguments[0] = `${prefix} ${logContent}`;
           }
         }
       } catch (error) {


### PR DESCRIPTION
### What does this PR do?
Stringifies non-string content that is passed to console.log when trace ID injection is enabled

### Motivation
Received a report of customer logging an object and seeing a log like this written to CW logs:
```
2021-05-19 16:18:03.839 (-04:00)        123-abc-defg-hijk-lmno INFO    [dd.trace_id=1234567 dd.span_id=1234567] [object Object]
```

### Testing Guidelines
* Deployed with a sample Lambda and saw the stringified object in the logs
* Added a unit test

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
