### PR TITLE
Bump node 10 version to 10.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        node-version: [10.15, 12.13, 14.15]
+        node-version: [10.24, 12.13, 14.15]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.15, 12.13, 14.15]
+        node-version: [10.24, 12.13, 14.15]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -11,7 +11,7 @@ set -e
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_node"
 
-NODE_VERSIONS=("10.15" "12.13" "14.15")
+NODE_VERSIONS=("10.24" "12.13" "14.15")
 
 if [ -z "$NODE_VERSION" ]; then
     echo "Node version not specified, running for all node versions."

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -11,7 +11,7 @@
 set -e
 
 NODE_VERSIONS_FOR_AWS_CLI=("nodejs10.x" "nodejs12.x" "nodejs14.x")
-LAYER_PATHS=(".layers/datadog_lambda_node10.15.zip" ".layers/datadog_lambda_node12.13.zip" ".layers/datadog_lambda_node14.15.zip")
+LAYER_PATHS=(".layers/datadog_lambda_node10.24.zip" ".layers/datadog_lambda_node12.13.zip" ".layers/datadog_lambda_node14.15.zip")
 AVAILABLE_LAYERS=("Datadog-Node10-x" "Datadog-Node12-x" "Datadog-Node14-x")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -29,7 +29,7 @@ mismatch_found=false
 # [0]: serverless runtime name
 # [1]: nodejs version
 # [2]: random 8-character ID to avoid collisions with other runs
-node10=("nodejs10.x" "10.15" $(xxd -l 4 -c 4 -p < /dev/random))
+node10=("nodejs10.x" "10.24" $(xxd -l 4 -c 4 -p < /dev/random))
 node12=("nodejs12.x" "12.13" $(xxd -l 4 -c 4 -p < /dev/random))
 node14=("nodejs14.x" "14.15" $(xxd -l 4 -c 4 -p < /dev/random))
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,7 +8,7 @@
 # Run unit tests in Docker
 set -e
 
-NODE_VERSIONS=("10.15" "12.13" "14.15")
+NODE_VERSIONS=("10.24" "12.13" "14.15")
 
 for node_version in "${NODE_VERSIONS[@]}"
 do

--- a/scripts/sign_layers.sh
+++ b/scripts/sign_layers.sh
@@ -8,7 +8,7 @@
 set -e
 
 LAYER_DIR=".layers"
-LAYER_FILES=("datadog_lambda_node10.15.zip" "datadog_lambda_node12.13.zip" "datadog_lambda_node14.15.zip")
+LAYER_FILES=("datadog_lambda_node10.24.zip" "datadog_lambda_node12.13.zip" "datadog_lambda_node14.15.zip")
 SIGNING_PROFILE_NAME="DatadogLambdaSigningProfile"
 
 # Check account parameter


### PR DESCRIPTION
### What does this PR do?

Bumps node version for v10 runtime, to use node 10.24. (This is the current node 10 runtime AWS is using).

### Motivation

This fixes compatibility issues with some dependencies, that was preventing updates.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
