### PR TITLE
Check for the new direct invocation trace format and use that

### DIFF
--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -228,7 +228,7 @@ export function readTraceFromLambdaContext(context: any): TraceContext | undefin
   if (!custom || typeof custom !== "object") {
     return;
   }
-  var traceData = null;
+  let traceData = null;
 
   if (
     custom._datadog &&

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -223,9 +223,28 @@ export function readTraceFromLambdaContext(context: any): TraceContext | undefin
     return;
   }
 
-  const traceData = context.clientContext?.custom?._datadog;
+  const custom = context.clientContext?.custom;
 
-  if (!traceData || typeof traceData !== "object") {
+  if (!custom || typeof custom !== "object") {
+    return;
+  }
+  var traceData = null;
+
+  if (
+    custom._datadog &&
+    typeof custom._datadog === "object" &&
+    custom._datadog.hasOwnProperty(traceIDHeader) &&
+    custom._datadog.hasOwnProperty(parentIDHeader) &&
+    custom._datadog.hasOwnProperty(samplingPriorityHeader)
+  ) {
+    traceData = custom._datadog;
+  } else if (
+    custom.hasOwnProperty(traceIDHeader) &&
+    custom.hasOwnProperty(parentIDHeader) &&
+    custom.hasOwnProperty(samplingPriorityHeader)
+  ) {
+    traceData = custom;
+  } else {
     return;
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates datadog-lambda-python so it can extract trace contexts stored in context.client_context.custom using the new propagation format, described in this doc: https://docs.google.com/document/d/1pruSeesAr2bAVMtz_rUlsiBZKFoFWdB4nSq5Vuym2l8/edit#heading=h.ptr8uhqw5ht



<!--- A brief description of the change being made with this pull request. --->

### Motivation

Storing a map containing trace context in context.client_context.custom._datadog causes compatibility issues with Go and Java lambda functions. C.f. aws/aws-lambda-java-libs#212. We're updating the trace propagation format to fix this issue.



<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
