### PR TITLE
Modify KMS import to speed up coldstarts

### DIFF
--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -7,7 +7,7 @@ if [ -z "$VERSION" ]; then
     echo "Version not specified."
     echo "Please specify the desired layer version (e.g. 5)."
     exit 1
-else
+fi
 
 ./scripts/build_layers.sh
 ./scripts/sign_layers.sh sandbox

--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -1,0 +1,73 @@
+import { KMSService } from "./kms-service";
+import nock from "nock";
+
+describe("KMSService", () => {
+  
+  it("decrypts", async () => {
+
+    const encryptedKEy = 'BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn'; //random fake key
+
+    //setting up the env variables
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-test-function';
+    process.env.AWS_ACCESS_KEY_ID="aaa";
+    process.env.AWS_SECRET_ACCESS_KEY="bbb";
+    process.env.AWS_REGION="us-east-1";
+    
+    const tests = [
+      { 
+        result : {
+          Plaintext: Buffer.from("myDecryptedKey")
+        },
+        expectedResult: "myDecryptedKey",
+        shouldRaiseAnError: false,
+        errorMsg: undefined,
+        statusCode: 200
+      },
+      { 
+        result : {},
+        expectedResult: undefined,
+        shouldRaiseAnError: true,
+        errorMsg: 'Couldn\'t decrypt value',
+        statusCode: 200,
+      },
+      { 
+        result : {},
+        expectedResult: undefined,
+        shouldRaiseAnError: true,
+        errorMsg: 'Couldn\'t decrypt value',
+        statusCode: 400,
+      }
+    ]
+
+    tests.forEach(async testCase => {
+      //faking the KMS call
+      const fakeCall = nock('https://kms.us-east-1.amazonaws.com:443', {"encodedQueryParams":true})
+      .post('/', {
+        CiphertextBlob:"BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+        EncryptionContext:{
+          LambdaFunctionName:"my-test-function"
+        }
+      })
+      .reply(testCase.statusCode, {
+        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        ...testCase.result
+      });
+
+      const kmsService = new KMSService();
+      if(testCase.shouldRaiseAnError) {
+          try {
+            await kmsService.decrypt(encryptedKEy);
+            fail();
+          } catch(e) {
+            expect(e.message).toEqual(testCase.errorMsg);
+          }
+      } else {
+          const result = await kmsService.decrypt(encryptedKEy);
+          expect(result).toEqual(testCase.expectedResult)
+      }
+
+      //verify that the call was actually done
+      fakeCall.done();
+    });
+  });
+});

--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -2,68 +2,66 @@ import { KMSService } from "./kms-service";
 import nock from "nock";
 
 describe("KMSService", () => {
-  
   it("decrypts", async () => {
-
-    const encryptedKEy = 'BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn'; //random fake key
+    const encryptedKEy = "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn"; //random fake key
 
     //setting up the env variables
-    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-test-function';
-    process.env.AWS_ACCESS_KEY_ID="aaa";
-    process.env.AWS_SECRET_ACCESS_KEY="bbb";
-    process.env.AWS_REGION="us-east-1";
-    
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "my-test-function";
+    process.env.AWS_ACCESS_KEY_ID = "aaa";
+    process.env.AWS_SECRET_ACCESS_KEY = "bbb";
+    process.env.AWS_REGION = "us-east-1";
+
     const tests = [
-      { 
-        result : {
-          Plaintext: Buffer.from("myDecryptedKey")
+      {
+        result: {
+          Plaintext: Buffer.from("myDecryptedKey"),
         },
         expectedResult: "myDecryptedKey",
         shouldRaiseAnError: false,
         errorMsg: undefined,
-        statusCode: 200
-      },
-      { 
-        result : {},
-        expectedResult: undefined,
-        shouldRaiseAnError: true,
-        errorMsg: 'Couldn\'t decrypt value',
         statusCode: 200,
       },
-      { 
-        result : {},
+      {
+        result: {},
         expectedResult: undefined,
         shouldRaiseAnError: true,
-        errorMsg: 'Couldn\'t decrypt value',
+        errorMsg: "Couldn't decrypt value",
+        statusCode: 200,
+      },
+      {
+        result: {},
+        expectedResult: undefined,
+        shouldRaiseAnError: true,
+        errorMsg: "Couldn't decrypt value",
         statusCode: 400,
-      }
-    ]
+      },
+    ];
 
-    tests.forEach(async testCase => {
+    tests.forEach(async (testCase) => {
       //faking the KMS call
-      const fakeCall = nock('https://kms.us-east-1.amazonaws.com:443', {"encodedQueryParams":true})
-      .post('/', {
-        CiphertextBlob:"BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-        EncryptionContext:{
-          LambdaFunctionName:"my-test-function"
-        }
-      })
-      .reply(testCase.statusCode, {
-        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-        ...testCase.result
-      });
+      const fakeCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
+        .post("/", {
+          CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+          EncryptionContext: {
+            LambdaFunctionName: "my-test-function",
+          },
+        })
+        .reply(testCase.statusCode, {
+          KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+          ...testCase.result,
+        });
 
       const kmsService = new KMSService();
-      if(testCase.shouldRaiseAnError) {
-          try {
-            await kmsService.decrypt(encryptedKEy);
-            fail();
-          } catch(e) {
-            expect(e.message).toEqual(testCase.errorMsg);
-          }
+      if (testCase.shouldRaiseAnError) {
+        try {
+          await kmsService.decrypt(encryptedKEy);
+          fail();
+        } catch (e) {
+          expect(e.message).toEqual(testCase.errorMsg);
+        }
       } else {
-          const result = await kmsService.decrypt(encryptedKEy);
-          expect(result).toEqual(testCase.expectedResult)
+        const result = await kmsService.decrypt(encryptedKEy);
+        expect(result).toEqual(testCase.expectedResult);
       }
 
       //verify that the call was actually done

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -3,7 +3,6 @@
 // tries to decrypt a value.
 
 export class KMSService {
-
   public async decrypt(value: string): Promise<string> {
     try {
       const kmsType = require("aws-sdk/clients/kms");
@@ -16,7 +15,7 @@ export class KMSService {
       }
       return result.Plaintext.toString("ascii");
     } catch (err) {
-      throw Error('Couldn\'t decrypt value');
+      throw Error("Couldn't decrypt value");
     }
   }
 }

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -1,36 +1,21 @@
-// This only imports the type of KMS, not the class. As we don't do an instantiation typescript will compile this away.
-import { KMS } from "aws-sdk";
-
-import { logError } from "../utils";
-
 // In order to avoid the layer adding the 40mb aws-sdk to a deployment, (which is always available
 // in the lambda environment anyway), we use require to import the sdk, and return an error if someone
 // tries to decrypt a value.
 export class KMSService {
-  private kms?: KMS;
-
-  constructor() {
-    try {
-      const kmsType = require("aws-sdk").KMS;
-      this.kms = new kmsType() as KMS;
-    } catch (err) {
-      logError("optional dependency aws-sdk not installed. KMS key decryption will not work", err);
-    }
-  }
 
   public async decrypt(value: string): Promise<string> {
-    if (this.kms === undefined) {
-      // This error should only occur if the user is running this code outside of the lambda environment,
-      // (say a local development environment).
+    try {
+      const kmsType = require("aws-sdk/clients/kms");
+      const kms = new kmsType();
+      const buffer = Buffer.from(value, "base64");
+      const encryptionContext = { LambdaFunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME ?? "" };
+      const result = await kms.decrypt({ CiphertextBlob: buffer, EncryptionContext: encryptionContext }).promise();
+      if (result.Plaintext === undefined) {
+        throw Error("Couldn't decrypt value");
+      }
+      return result.Plaintext.toString("ascii");
+    } catch (err) {
       throw Error("optional dependency aws-sdk not installed. KMS key decryption will not work");
     }
-    const buffer = Buffer.from(value, "base64");
-
-    const encryptionContext = { LambdaFunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME ?? "" };
-    const result = await this.kms.decrypt({ CiphertextBlob: buffer, EncryptionContext: encryptionContext }).promise();
-    if (result.Plaintext === undefined) {
-      throw Error("Couldn't decrypt value");
-    }
-    return result.Plaintext.toString("ascii");
   }
 }

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -1,6 +1,7 @@
 // In order to avoid the layer adding the 40mb aws-sdk to a deployment, (which is always available
 // in the lambda environment anyway), we use require to import the sdk, and return an error if someone
 // tries to decrypt a value.
+
 export class KMSService {
 
   public async decrypt(value: string): Promise<string> {
@@ -11,11 +12,11 @@ export class KMSService {
       const encryptionContext = { LambdaFunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME ?? "" };
       const result = await kms.decrypt({ CiphertextBlob: buffer, EncryptionContext: encryptionContext }).promise();
       if (result.Plaintext === undefined) {
-        throw Error("Couldn't decrypt value");
+        throw Error();
       }
       return result.Plaintext.toString("ascii");
     } catch (err) {
-      throw Error("optional dependency aws-sdk not installed. KMS key decryption will not work");
+      throw Error('Couldn\'t decrypt value');
     }
   }
 }

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -2,6 +2,8 @@
 // in the lambda environment anyway), we use require to import the sdk, and return an error if someone
 // tries to decrypt a value.
 
+import { logError } from "../utils";
+
 export class KMSService {
   public async decrypt(value: string): Promise<string> {
     try {
@@ -15,6 +17,11 @@ export class KMSService {
       }
       return result.Plaintext.toString("ascii");
     } catch (err) {
+      if(err.code === 'MODULE_NOT_FOUND') {
+        const errorMsg = "optional dependency aws-sdk not installed. KMS key decryption will not work";
+        logError(errorMsg);
+        throw Error(errorMsg);
+      }
       throw Error("Couldn't decrypt value");
     }
   }

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -17,7 +17,7 @@ export class KMSService {
       }
       return result.Plaintext.toString("ascii");
     } catch (err) {
-      if(err.code === 'MODULE_NOT_FOUND') {
+      if (err.code === "MODULE_NOT_FOUND") {
         const errorMsg = "optional dependency aws-sdk not installed. KMS key decryption will not work";
         logError(errorMsg);
         throw Error(errorMsg);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- import a more specific (lighter) package
- move import logic to decrypt (this way if a lambda does not use KMS, we skip the KMS loading time as well
- unit test kms-service

### Motivation

Performance

### Testing Guidelines

Unit tests

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
