### PR TITLE
Support decrypting API keys that were encrypted without an encryption context

### DIFF
--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: VERSION=5 aws-vault exec sandbox-acccount-admin -- publish_layers.sh
+# Usage: VERSION=5 aws-vault exec sandbox-acccount-admin -- publish_sandbox.sh
 set -e
 
 if [ -z "$VERSION" ]; then
@@ -9,6 +9,6 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
-./scripts/build_layers.sh
-./scripts/sign_layers.sh sandbox
+# ./scripts/build_layers.sh
+# ./scripts/sign_layers.sh sandbox
 VERSION=$VERSION REGIONS=sa-east-1 ./scripts/publish_layers.sh

--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -3,6 +3,7 @@ import nock from "nock";
 
 describe("KMSService", () => {
   const ENCRYPTED_KEY = "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn"; // random fake key
+  const KEY_ID = "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab";
   const EXPECTED_RESULT = "myDecryptedKey";
   const EXPECTED_ERROR_MESSAGE = "Couldn't decrypt ciphertext";
 
@@ -26,7 +27,7 @@ describe("KMSService", () => {
         CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
       })
       .reply(400, {
-        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        KeyId: KEY_ID,
       });
 
     const secondFakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
@@ -37,7 +38,7 @@ describe("KMSService", () => {
         },
       })
       .reply(200, {
-        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        KeyId: KEY_ID,
         Plaintext: Buffer.from(EXPECTED_RESULT),
       });
 
@@ -54,7 +55,7 @@ describe("KMSService", () => {
         CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
       })
       .reply(200, {
-        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        KeyId: KEY_ID,
         Plaintext: Buffer.from(EXPECTED_RESULT),
       });
 
@@ -68,12 +69,9 @@ describe("KMSService", () => {
     const fakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
       .post("/", {
         CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-        EncryptionContext: {
-          LambdaFunctionName: "my-test-function",
-        },
       })
       .reply(400, {
-        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        KeyId: KEY_ID,
       });
 
     const kmsService = new KMSService();

--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -2,70 +2,87 @@ import { KMSService } from "./kms-service";
 import nock from "nock";
 
 describe("KMSService", () => {
-  it("decrypts", async () => {
-    const encryptedKEy = "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn"; //random fake key
+  const ENCRYPTED_KEY = "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn"; // random fake key
+  const EXPECTED_RESULT = "myDecryptedKey"
+  const EXPECTED_ERROR_MESSAGE = "Couldn't decrypt ciphertext"
 
-    //setting up the env variables
+  beforeAll(() => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = "my-test-function";
     process.env.AWS_ACCESS_KEY_ID = "aaa";
     process.env.AWS_SECRET_ACCESS_KEY = "bbb";
     process.env.AWS_REGION = "us-east-1";
+  });
 
-    const tests = [
-      {
-        result: {
-          Plaintext: Buffer.from("myDecryptedKey"),
-        },
-        expectedResult: "myDecryptedKey",
-        shouldRaiseAnError: false,
-        errorMsg: undefined,
-        statusCode: 200,
-      },
-      {
-        result: {},
-        expectedResult: undefined,
-        shouldRaiseAnError: true,
-        errorMsg: "Couldn't decrypt value",
-        statusCode: 200,
-      },
-      {
-        result: {},
-        expectedResult: undefined,
-        shouldRaiseAnError: true,
-        errorMsg: "Couldn't decrypt value",
-        statusCode: 400,
-      },
-    ];
+  afterAll(() => {
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_REGION;
+  });
 
-    tests.forEach(async (testCase) => {
-      //faking the KMS call
-      const fakeCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
-        .post("/", {
-          CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-          EncryptionContext: {
-            LambdaFunctionName: "my-test-function",
-          },
-        })
-        .reply(testCase.statusCode, {
-          KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-          ...testCase.result,
-        });
-
-      const kmsService = new KMSService();
-      if (testCase.shouldRaiseAnError) {
-        try {
-          await kmsService.decrypt(encryptedKEy);
-          fail();
-        } catch (e) {
-          expect(e.message).toEqual(testCase.errorMsg);
-        }
-      } else {
-        const result = await kmsService.decrypt(encryptedKEy);
-        expect(result).toEqual(testCase.expectedResult);
-      }
-
-      //verify that the call was actually done
-      fakeCall.done();
+  it("decrypts when the API key was encrypted with an encryption context", async () => {
+    const firstFakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
+    .post("/", {
+      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+    })
+    .reply(400, {
+      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
     });
+
+    const secondFakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
+    .post("/", {
+      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+      EncryptionContext: {
+        LambdaFunctionName: "my-test-function",
+      },
+    })
+    .reply(200, {
+      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+      Plaintext: Buffer.from(EXPECTED_RESULT),
+    });
+
+    const kmsService = new KMSService();
+    const result = await kmsService.decrypt(ENCRYPTED_KEY);
+    expect(result).toEqual(EXPECTED_RESULT);
+    firstFakeKmsCall.done();
+    secondFakeKmsCall.done();
+  });
+
+  it("decrypts when the API key was encrypted without an encryption context", async () => {
+    const fakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
+    .post("/", {
+      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+    })
+    .reply(200, {
+      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+      Plaintext: Buffer.from(EXPECTED_RESULT),
+    });
+
+    const kmsService = new KMSService();
+    const result = await kmsService.decrypt(ENCRYPTED_KEY);
+    expect(result).toEqual(EXPECTED_RESULT);
+    fakeKmsCall.done();
+  });
+
+  it("throws an error when unable to decrypt", async () => {
+    const fakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
+    .post("/", {
+      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+      EncryptionContext: {
+        LambdaFunctionName: "my-test-function",
+      },
+    })
+    .reply(400, {
+      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+    });
+
+    const kmsService = new KMSService();
+    try {
+      await kmsService.decrypt(ENCRYPTED_KEY);
+      fail()
+    } catch (e) {
+      expect(e.message).toEqual(EXPECTED_ERROR_MESSAGE)
+    }
+    fakeKmsCall.done();
   });
 });

--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -3,8 +3,8 @@ import nock from "nock";
 
 describe("KMSService", () => {
   const ENCRYPTED_KEY = "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRn"; // random fake key
-  const EXPECTED_RESULT = "myDecryptedKey"
-  const EXPECTED_ERROR_MESSAGE = "Couldn't decrypt ciphertext"
+  const EXPECTED_RESULT = "myDecryptedKey";
+  const EXPECTED_ERROR_MESSAGE = "Couldn't decrypt ciphertext";
 
   beforeAll(() => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = "my-test-function";
@@ -22,24 +22,24 @@ describe("KMSService", () => {
 
   it("decrypts when the API key was encrypted with an encryption context", async () => {
     const firstFakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
-    .post("/", {
-      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-    })
-    .reply(400, {
-      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-    });
+      .post("/", {
+        CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+      })
+      .reply(400, {
+        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+      });
 
     const secondFakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
-    .post("/", {
-      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-      EncryptionContext: {
-        LambdaFunctionName: "my-test-function",
-      },
-    })
-    .reply(200, {
-      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-      Plaintext: Buffer.from(EXPECTED_RESULT),
-    });
+      .post("/", {
+        CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+        EncryptionContext: {
+          LambdaFunctionName: "my-test-function",
+        },
+      })
+      .reply(200, {
+        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        Plaintext: Buffer.from(EXPECTED_RESULT),
+      });
 
     const kmsService = new KMSService();
     const result = await kmsService.decrypt(ENCRYPTED_KEY);
@@ -50,13 +50,13 @@ describe("KMSService", () => {
 
   it("decrypts when the API key was encrypted without an encryption context", async () => {
     const fakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
-    .post("/", {
-      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-    })
-    .reply(200, {
-      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-      Plaintext: Buffer.from(EXPECTED_RESULT),
-    });
+      .post("/", {
+        CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+      })
+      .reply(200, {
+        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        Plaintext: Buffer.from(EXPECTED_RESULT),
+      });
 
     const kmsService = new KMSService();
     const result = await kmsService.decrypt(ENCRYPTED_KEY);
@@ -66,22 +66,22 @@ describe("KMSService", () => {
 
   it("throws an error when unable to decrypt", async () => {
     const fakeKmsCall = nock("https://kms.us-east-1.amazonaws.com:443", { encodedQueryParams: true })
-    .post("/", {
-      CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
-      EncryptionContext: {
-        LambdaFunctionName: "my-test-function",
-      },
-    })
-    .reply(400, {
-      KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-    });
+      .post("/", {
+        CiphertextBlob: "BQICAHj0djbIQaGrIfSD2gstvRF3h8YGMeEvO5rRHNiuWwSeegEFl57KxNejRg==",
+        EncryptionContext: {
+          LambdaFunctionName: "my-test-function",
+        },
+      })
+      .reply(400, {
+        KeyId: "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+      });
 
     const kmsService = new KMSService();
     try {
       await kmsService.decrypt(ENCRYPTED_KEY);
-      fail()
+      fail();
     } catch (e) {
-      expect(e.message).toEqual(EXPECTED_ERROR_MESSAGE)
+      expect(e.message).toEqual(EXPECTED_ERROR_MESSAGE);
     }
     fakeKmsCall.done();
   });


### PR DESCRIPTION
### What does this PR do?

Previously, we assumed that the `DD_KMS_API_KEY` was encrypted using the AWS console. When the API key is encrypted using the console, the console uses the Lambda function's name as an "encryption context". We need to provide this same encryption context in the decrypt call to successfully decrypt the API key. However, if the customer encrypts the API key using the AWS CLI, it will not have this encryption context and the decrypt call will fail.

With this PR, we will first try decrypting the API key without an encryption context, and then attempt to decrypt it with the decryption context.

### Motivation

Encrypting the API key using the AWS console does not work well with our deployment tools, because we expect the customer to provide a single encrypted API key that will work across multiple functions. Because the AWS console uses the Lambda function's name as the encryption context, each encrypted API key will only work with that individual Lambda function.

### Testing Guidelines

Unit test coverage.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
