### PR TITLE
Do not automatically open PRs updating packages to latest major version

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Update Dependencies
         run: |
           yarn install
-          yarn upgrade --latest
+          yarn upgrade
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
### What does this PR do?

There is a GitHub workflow that runs at 10 AM every day to open a PR updating dependencies. Currently, this workflow will update packages to the latest major version, even if there is a breaking change. For example, it opened [this PR](https://github.com/DataDog/datadog-lambda-js/pull/189) which tried to update `mock-fs` from version 4.x to version 5.x.

Because major versions entail breaking changes, it's not safe to automatically update dependencies to the latest major version. Instead we should respect the dependency ranges specified in the `package.json` file.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
