### PR TITLE
Remove the forced 50ms wait when closing the StatsD server

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "aws-xray-sdk-core": "^3.3.3",
     "bignumber.js": "^9.0.1",
-    "hot-shots": "8.3.1",
+    "hot-shots": "8.5.0",
     "promise-retry": "^2.0.1",
     "serialize-error": "^8.1.0",
     "shimmer": "^1.2.1"

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -68,7 +68,7 @@ export class MetricsListener {
     if (this.isAgentRunning) {
       logDebug(`Using StatsD client`);
 
-      this.statsDClient = new StatsD({ host: "127.0.0.1" });
+      this.statsDClient = new StatsD({ host: "127.0.0.1", closingFlushInterval: 1 });
       return;
     }
     if (this.config.logForwarding) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,10 +1552,10 @@ hdr-histogram-js@^2.0.1:
     base64-js "^1.2.0"
     pako "^1.0.3"
 
-hot-shots@8.3.1:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-8.3.1.tgz#de262964cd506978f03218e2d1f0bcd90b931093"
-  integrity sha512-eB20m2neM+uV7IM3JDCZg8/NU1+WGM7Qh7kpvC/sGIWNg4Ng+9O8JT/zrLuA+2JStiQLEy9z/9VEDFH0BzYf0A==
+hot-shots@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-8.5.0.tgz#860246a3694dfb74cfe6045501eb59fb57e16eb9"
+  integrity sha512-GNXtNSxa9qibcPhi3gndyN5g14iBJS+/DDlu7hjSPfXYJy9/fcO13DgSyfPUVWrD/aIyPY36z7MksHvDe05zYg==
   optionalDependencies:
     unix-dgram "2.0.x"
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Since https://github.com/brightcove/hot-shots/pull/209 has been merged and released here : https://github.com/brightcove/hot-shots/blob/master/CHANGES.md this PR bumps hot-shots to the new released version and make use of the newly introduced parameter `closingFlushInterval` to shutdown StatsD quicker

### Motivation

Performance improvements

### Testing Guidelines

Current version :
<img width="1266" alt="current" src="https://user-images.githubusercontent.com/864493/126168178-84d80d30-4f40-4954-a2a1-c8f8cd3e1f6c.png">

With the fix : 
<img width="1250" alt="withFix" src="https://user-images.githubusercontent.com/864493/126168180-28adcda6-9386-4472-8f8a-664b231d79da.png">

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
