### PR TITLE
Properly exclude Lambda Extension spans 

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,7 +24,7 @@ if (getEnvValue("DD_TRACE_ENABLED", "true").toLowerCase() === "true") {
 
   // Configure the tracer to ignore HTTP calls made from the Lambda Library to the Extension
   tracer.use("http", {
-    blocklist: /8124\/lambda/,
+    blocklist: /:8124\/lambda/,
   });
 }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,9 +24,7 @@ if (getEnvValue("DD_TRACE_ENABLED", "true").toLowerCase() === "true") {
 
   // Configure the tracer to ignore HTTP calls made from the Lambda Library to the Extension
   tracer.use("http", {
-    // blacklist has been deprecated in favor of blocklist, but we still use it here for
-    // compatibility with older versions of the tracer
-    blacklist: /:8124/,
+    blocklist: /8124\/lambda/,
   });
 }
 


### PR DESCRIPTION
### What does this PR do?

Switches from the deprecated `blacklist` option in dd-trace-js to the newer `blocklist` when excluding HTTP calls made from dd-lambda-js to the Lambda Extension. The deprecated option is not working properly.

I also updated the blocklist regex from `:8124` to `8124\/lambda`. Both of these regexes work fine for excluding the span, but the new regex will allow other requests made on port 8124 to be traced.

### Motivation

In certain situations, the tracer records a span representing the HTTP call that dd-lambda-js makes to the Lambda Extension at the end of an invocation. It is still unclear to me what exact situations this happens in, but it seems to be caused by differences in the exact order in which modules are imported.

Either way, we want to exclude these spans in all cases. The option we are currently using in dd-trace-js is not working properly, so switching to the newer option will solve the issue for us. I have also reported the issue with the deprecated option to the dd-trace-js team.

### Testing Guidelines

I manually tested 16 different combinations of changes to identify and confirm the cause of the issue and its solution.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
