### PR TITLE
Strip unused files from the layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,7 @@ RUN rm -rf /nodejs/node_modules/dd-trace/prebuilds
 RUN rm -rf /nodejs/node_modules/dd-trace/dist
 RUN rm -rf /nodejs/node_modules/hdr-histogram-js/build
 RUN rm -rf /nodejs/node_modules/protobufjs/dist
+RUN rm -rf /nodejs/node_modules/protobufjs/cli
+RUN find /nodejs/node_modules -name "*.d.ts" -delete
+RUN find /nodejs/node_modules -name "*.js.map" -delete
+RUN find /nodejs/node_modules -name "*.ts.map" -delete


### PR DESCRIPTION
### What does this PR do?

This PR strips additional unused files from the node layer, including the protobuf cli tool, .d.ts files and source maps.

### Motivation

Decompressed layer size drops 10mb to 4.8mb.

### Testing Guidelines


### Additional Notes


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
