### PR TITLE
feat: support reading trace context from AppSync event

### DIFF
--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -200,6 +200,24 @@ describe("readTraceFromEvent", () => {
       source: Source.Event,
     });
   });
+  it("can read from appsync source", () => {
+    const result = readTraceFromEvent({
+      info: { variables: {}},
+      request: {
+        headers: {
+          "x-datadog-parent-id": "797643193680388254",
+          "x-datadog-sampling-priority": "2",
+          "x-datadog-trace-id": "4110911582297405557",
+        }
+      },
+    });
+    expect(result).toEqual({
+      parentID: "797643193680388254",
+      sampleMode: SampleMode.USER_KEEP,
+      traceID: "4110911582297405557",
+      source: Source.Event,
+    });
+  });
   it("can read from sqs source", () => {
     const result = readTraceFromEvent({
       Records: [

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -5,7 +5,7 @@ import { createSocket, Socket } from "dgram";
 import { SQSEvent } from "aws-lambda";
 
 import { logDebug, logError } from "../utils";
-import { isSQSEvent } from "../utils/event-type-guards";
+import { isAppSyncResolverEvent, isSQSEvent } from "../utils/event-type-guards";
 import {
   parentIDHeader,
   SampleMode,
@@ -177,6 +177,11 @@ export function sendXraySubsegment(segment: string) {
   }
 }
 
+export function readTraceFromAppSyncEvent(event: any): TraceContext | undefined {
+  event.headers = event.request.headers;
+  return readTraceFromHTTPEvent(event);
+}
+
 export function readTraceFromSQSEvent(event: SQSEvent): TraceContext | undefined {
   if (
     event.Records[0].messageAttributes &&
@@ -312,6 +317,10 @@ export function readTraceFromEvent(event: any): TraceContext | undefined {
 
   if (event.headers !== null && typeof event.headers === "object") {
     return readTraceFromHTTPEvent(event);
+  }
+
+  if (isAppSyncResolverEvent(event)) {
+    return readTraceFromAppSyncEvent(event);
   }
 
   if (isSQSEvent(event)) {

--- a/src/utils/event-type-guards.ts
+++ b/src/utils/event-type-guards.ts
@@ -1,6 +1,7 @@
 import {
   APIGatewayEvent,
   APIGatewayProxyEventV2,
+  AppSyncResolverEvent,
   ALBEvent,
   CloudWatchLogsEvent,
   ScheduledEvent,
@@ -57,4 +58,8 @@ export function isSNSEvent(event: any): event is SNSEvent {
 
 export function isSQSEvent(event: any): event is SQSEvent {
   return Array.isArray(event.Records) && event.Records.length > 0 && event.Records[0].eventSource === "aws:sqs";
+}
+
+export function isAppSyncResolverEvent(event: any): event is AppSyncResolverEvent<any> {
+  return event.info !== undefined && event.info.variables !== undefined;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adds support for reading the datadog headers from an AppSync event, without requiring users to use custom trace extractors.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
