### PR TITLE
feat: allow apiKey config option to be a promise

### DIFF
--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -22,7 +22,7 @@ export interface MetricsConfig {
    * The api key used to talk to the Datadog API. If this is empty, apiKeyKMS key
    * will be used instead.
    */
-  apiKey: string;
+  apiKey: string | Promise<string>;
   /**
    * A KMS encrypted api key used to talk to the Datadog API. It will automatically
    * be decrypted before any metrics are sent.


### PR DESCRIPTION
* this allows fetching the apiKey during runtime and removes the need to have the key clearly visible in the environment or using a workaround with KMS for multiple accounts and environments

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adjusts the type of `config.apiKey` to also include `Promise<string>`.
As the `apiKey` is used in tandem with `apiKeyKms`, changing it to a promise should not introduce any issues.

Allowing the `apiKey` to be a promise allows the user to fetch the `apiKey` from a third party (e.g. SecretsManager without exposing it in a lambda environment.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

I want to be able to use an `apiKey` that is stored in SecretsManager by only exposing the arn in the lambda environment.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

I added a unit test and tested it by locally installing the module and deploying it to our test system.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
