### PR TITLE
Fix enhanced.errors metric when using Lambda Extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,11 +160,11 @@ export function datadog<TEvent, TResult>(
       error = err;
     }
     try {
-      await metricsListener.onCompleteInvocation();
-      await traceListener.onCompleteInvocation();
       if (didThrow && finalConfig.enhancedMetrics) {
         incrementErrorsMetric(metricsListener, context);
       }
+      await metricsListener.onCompleteInvocation();
+      await traceListener.onCompleteInvocation();
     } catch (err) {
       if (err instanceof Error) {
         logDebug("Failed to complete listeners", err);


### PR DESCRIPTION
### What does this PR do?

Previously, we incremented the `aws.lambda.enhanced.errors` metric in a window of time between invocations during which the StatsD client is not available. This resulted in the metric not being sent to the Lambda Extension.

### Testing Guidelines

I have added integration test coverage in the `datadog-lambda-extension` repository, which will be a separate pull request.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
