### PR TITLE
add arm64 to compatible architectures

### DIFF
--- a/scripts/add_new_region.sh
+++ b/scripts/add_new_region.sh
@@ -17,6 +17,7 @@ publish_layer() {
         --zip-file "fileb://$layer_path" \
         --region $region \
         --compatible-runtimes $aws_version_key \
+        --compatible-architectures "arm64" "x86_64" 
                         | jq -r '.Version')
 
     aws lambda add-layer-version-permission --layer-name $layer_name \


### PR DESCRIPTION
### What does this PR do?

This PR adds compatible arm64 as a compatible architecture for the DataDog Layer.
This PR is linked to [this issue](https://github.com/DataDog/datadog-lambda-js/issues/250).

### Motivation

We use DataDog Layer to capture enhanced metrics and we would like to change our lambdas to ARM architecture.

### Testing Guidelines

N/A

### Additional Notes

N/A

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
