### PR TITLE
Span Inferrer: Fix path for API Gateway V1

### DIFF
--- a/src/trace/span-inferrer.spec.ts
+++ b/src/trace/span-inferrer.spec.ts
@@ -227,7 +227,7 @@ describe("SpanInferrer", () => {
         apiid: "id",
         endpoint: "/my/path",
         "http.url": "id.execute-api.us-east-1.amazonaws.com/my/path",
-        "domain_name": "id.execute-api.us-east-1.amazonaws.com",
+        domain_name: "id.execute-api.us-east-1.amazonaws.com",
         operation_name: "aws.apigateway",
         request_id: undefined,
         "http.method": "GET",
@@ -236,7 +236,7 @@ describe("SpanInferrer", () => {
         service: "id.execute-api.us-east-1.amazonaws.com",
         "service.name": "id.execute-api.us-east-1.amazonaws.com",
         "span.type": "http",
-        "stage": "$default"
+        stage: "$default",
       },
     });
   });
@@ -252,7 +252,7 @@ describe("SpanInferrer", () => {
         apiid: "r3pmxmplak",
         endpoint: "/default/nodejs-apig-function-1G3XMPLZXVXYI",
         "http.url": "r3pmxmplak.execute-api.us-east-2.amazonaws.com/default/nodejs-apig-function-1G3XMPLZXVXYI",
-        "domain_name": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+        domain_name: "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
         operation_name: "aws.apigateway",
         request_id: undefined,
         "http.method": "GET",
@@ -261,7 +261,7 @@ describe("SpanInferrer", () => {
         service: "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
         "service.name": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
         "span.type": "http",
-        "stage": "default"
+        stage: "default",
       },
     });
   });

--- a/src/trace/span-inferrer.spec.ts
+++ b/src/trace/span-inferrer.spec.ts
@@ -7,6 +7,8 @@ const ddbEvent = require("../../event_samples/dynamodb.json");
 const kinesisEvent = require("../../event_samples/kinesis.json");
 const eventBridgeEvent = require("../../event_samples/eventbridge.json");
 const webSocketEvent = require("../../event_samples/api-gateway-wss.json");
+const apiGatewayV1 = require("../../event_samples/api-gateway-v1.json");
+const apiGatewayV2 = require("../../event_samples/api-gateway-v2.json");
 const s3Event = require("../../event_samples/s3.json");
 const mockWrapper = {
   startSpan: jest.fn(),
@@ -210,6 +212,56 @@ describe("SpanInferrer", () => {
         service: "08se3mvh28.execute-api.sa-east-1.amazonaws.com",
         "service.name": "08se3mvh28.execute-api.sa-east-1.amazonaws.com",
         "span.type": "http",
+      },
+    });
+  });
+  it("creates an inferred span for API Gateway V1 events", () => {
+    const inferrer = new SpanInferrer(mockWrapper as unknown as TracerWrapper);
+    inferrer.createInferredSpan(apiGatewayV1, {} as any, {} as SpanContext);
+
+    expect(mockWrapper.startSpan).toBeCalledWith("aws.apigateway", {
+      childOf: {},
+      startTime: undefined,
+      tags: {
+        _inferred_span: { synchronicity: undefined, tag_source: "self" },
+        apiid: "id",
+        endpoint: "/my/path",
+        "http.url": "id.execute-api.us-east-1.amazonaws.com/my/path",
+        "domain_name": "id.execute-api.us-east-1.amazonaws.com",
+        operation_name: "aws.apigateway",
+        request_id: undefined,
+        "http.method": "GET",
+        "resource.name": "id.execute-api.us-east-1.amazonaws.com /my/path",
+        resource_names: "id.execute-api.us-east-1.amazonaws.com /my/path",
+        service: "id.execute-api.us-east-1.amazonaws.com",
+        "service.name": "id.execute-api.us-east-1.amazonaws.com",
+        "span.type": "http",
+        "stage": "$default"
+      },
+    });
+  });
+  it("creates an inferred span for API Gateway V2 events", () => {
+    const inferrer = new SpanInferrer(mockWrapper as unknown as TracerWrapper);
+    inferrer.createInferredSpan(apiGatewayV2, {} as any, {} as SpanContext);
+
+    expect(mockWrapper.startSpan).toBeCalledWith("aws.apigateway", {
+      childOf: {},
+      startTime: 1583817383220,
+      tags: {
+        _inferred_span: { synchronicity: undefined, tag_source: "self" },
+        apiid: "r3pmxmplak",
+        endpoint: "/default/nodejs-apig-function-1G3XMPLZXVXYI",
+        "http.url": "r3pmxmplak.execute-api.us-east-2.amazonaws.com/default/nodejs-apig-function-1G3XMPLZXVXYI",
+        "domain_name": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+        operation_name: "aws.apigateway",
+        request_id: undefined,
+        "http.method": "GET",
+        "resource.name": "r3pmxmplak.execute-api.us-east-2.amazonaws.com /default/nodejs-apig-function-1G3XMPLZXVXYI",
+        resource_names: "r3pmxmplak.execute-api.us-east-2.amazonaws.com /default/nodejs-apig-function-1G3XMPLZXVXYI",
+        service: "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+        "service.name": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
+        "span.type": "http",
+        "stage": "default"
       },
     });
   });

--- a/src/trace/span-inferrer.ts
+++ b/src/trace/span-inferrer.ts
@@ -55,7 +55,7 @@ export class SpanInferrer {
   ): SpanWrapper {
     const options: SpanOptions = {};
     const domain = event.requestContext.domainName;
-    const path = event.rawPath || event.requestContext.routeKey;
+    const path = event.rawPath || event.requestContext.path || event.requestContext.routeKey;
     let method;
     if (event.requestContext.httpMethod) {
       method = event.requestContext.httpMethod;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This Pull Request fixes the span inferrer for API Gateway V1 events.

### Motivation

Because of this bug, resources are not shown right in DataDog API Gateway service.

### Testing Guidelines

I wrote a until test which replicates the bug.

### Additional Notes

Looks like this problem happens only for API Gateway V1, but I also added an additional test case for API Gateway V2 just to make sure that my changes are not breaking something V2 related.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
