### PR TITLE
feat: Support binary based decoding for SNS message attributes

### DIFF
--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -261,6 +261,48 @@ describe("readTraceFromEvent", () => {
       traceID: "6966585609680374559",
     });
   });
+
+  it("can parse an SNS message source passing Binary trace context", () => {
+    const result = readTraceFromEvent({
+      Records: [
+        {
+          EventSource: "aws:sns",
+          EventVersion: "1.0",
+          EventSubscriptionArn:
+            "arn:aws:sns:sa-east-1:601427279990:aj-js-library-test-dev-solo-topic:1bd19208-a99a-46d9-8398-f90f8699c641",
+          Sns: {
+            Type: "Notification",
+            MessageId: "f19d39fa-8c61-5df9-8f49-639247b6cece",
+            TopicArn: "arn:aws:sns:sa-east-1:601427279990:aj-js-library-test-dev-solo-topic",
+            Subject: null,
+            Message: '{"hello":"there","ajTimestamp":1643039127879}',
+            Timestamp: "2022-01-24T15:45:27.968Z",
+            SignatureVersion: "1",
+            Signature:
+              "mzp2Ou0fASw4LYRxY6SSww7qFfofn4luCJBRaTjLpQ5uhwhsAUKdyLz9VPD+/dlRbi1ImsWtIZ7A+wxj1oV7Z2Gyu/N4RpGalae37+jTluDS7AhjgcD7Bs4bgQtFkCfMFEwbhICQfukLLzbwbgczZ4NTPn6zj5o28c5NBKSJMYSnLz82ohw77GgnZ/m26E32ZQNW4+VCEMINg9Ne2rHstwPWRXPr5xGTrx8jH8CNUZnVpFVfhU8o+OSeAdpzm2l99grHIo7qPhekERxANz6QHynMlhdzD3UNSgc3oZkamZban/NEKd4MKJzgNQdNOYVj3Kw6eF2ZweEoBQ5sSFK5fQ==",
+            SigningCertUrl:
+              "https://sns.sa-east-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",
+            UnsubscribeUrl:
+              "https://sns.sa-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:sa-east-1:601427279990:aj-js-library-test-dev-solo-topic:1bd19208-a99a-46d9-8398-f90f8699c641",
+            MessageAttributes: {
+              _datadog: {
+                Type: "Binary",
+                Value:
+                  "eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI3MTAyMjkxNjI4NDQzMTM0OTE5IiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjQyNDc1NTAxMDE2NDg2MTg2MTgiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIn0=",
+              },
+            },
+          },
+        },
+      ],
+    });
+    expect(result).toEqual({
+      parentID: "4247550101648618618",
+      sampleMode: 1,
+      source: "event",
+      traceID: "7102291628443134919",
+    });
+  });
+
   it("can read from SNS message delivered to SQS queue source", () => {
     const result = readTraceFromEvent({
       Records: [
@@ -282,6 +324,42 @@ describe("readTraceFromEvent", () => {
           awsRegion: "sa-east-1",
         },
       ],
+    });
+    expect(result).toEqual({
+      parentID: "4493917105238181843",
+      sampleMode: 1,
+      source: "event",
+      traceID: "2776434475358637757",
+    });
+  });
+
+  it("can read from SNS message delivered to SQS queue source with Binary trace context", () => {
+    const result = readTraceFromEvent({
+      Records: [
+        {
+          messageId: "64812b68-4d9b-4dca-b3fb-9b18f255ee51",
+          receiptHandle:
+            "AQEBER6aRkfG8092GvkL7FRwCwbQ7LLDW9Tlk/CembqHe+suS2kfFxXiukomvaIN61QoyQMoRgWuV52SDkiQno2u+5hP64BDbmw+e/KR9ayvIfHJ3M6RfyQLaWNWm3hDFBCKTnBMVIxtdx0N9epZZewyokjKcrNYtmCghFgTCvZzsQkowi5rnoHAVHJ3je1c3bDnQ1KLrZFgajDnootYXDwEPuMq5FIxrf4EzTe0S7S+rnRm+GaQfeBLBVAY6dASL9usV3/AFRqDtaI7GKI+0F2NCgLlqj49VlPRz4ldhkGknYlKTZTluAqALWLJS62/J1GQo53Cs3nneJcmu5ajB2zzmhhRXoXINEkLhCD5ujZfcsw9H4xqW69Or4ECvlqx14bUU2rtMIW0QM2p7pEeXnyocymQv6m1te113eYWTVmaJ4I=",
+          body: '{\n  "Type" : "Notification",\n  "MessageId" : "0a0ab23e-4861-5447-82b7-e8094ff3e332",\n  "TopicArn" : "arn:aws:sns:sa-east-1:601427279990:js-library-test-dev-demoTopic-15WGUVRCBMPAA",\n  "Message" : "{\\"hello\\":\\"harv\\",\\"nice of you to join us\\":\\"david\\",\\"anotherThing\\":{\\"foo\\":\\"bar\\",\\"blah\\":null,\\"harv\\":123},\\"vals\\":[{\\"thingOne\\":1},{\\"thingTwo\\":2}],\\"ajTimestamp\\":1639777617957}",\n  "Timestamp" : "2021-12-17T21:46:58.040Z",\n  "SignatureVersion" : "1",\n  "Signature" : "FR35/7E8C3LHEVk/rC4XxXlXwV/5mNkFNPgDhHSnJ2I6hIoSrTROAm7h5xm1PuBkAeFDvq0zofw91ouk9zZyvhdrMLFIIgrjEyNayRmEffmoEAkzLFUsgtQX7MmTl644r4NuWiM0Oiz7jueRvIcKXcZr7Nc6GJcWV1ymec8oOmuHNMisnPMxI07LIQVYSyAfv6P9r2jEWMVIukRoCzwTnRk4bUUYhPSGHI7OC3AsxxXBbv8snqTrLM/4z2rXCf6jHCKNxWeLlm9/45PphCkEyx5BWS4/71KaoMWUWy8+6CCsy+uF3XTCVmvSEYLyEwTSzOY+vCUjazrRW93498i70g==",\n  "SigningCertURL" : "https://sns.sa-east-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",\n  "UnsubscribeURL" : "https://sns.sa-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:sa-east-1:601427279990:js-library-test-dev-demoTopic-15WGUVRCBMPAA:1290f550-9a8a-4e8f-a900-8f5f96dcddda",\n  "MessageAttributes" : {\n    "_datadog" : {"Type":"Binary","Value":"eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI3MTAyMjkxNjI4NDQzMTM0OTE5IiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjQyNDc1NTAxMDE2NDg2MTg2MTgiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIn0="}\n  }\n}',
+          attributes: {
+            ApproximateReceiveCount: "1",
+            SentTimestamp: "1639777618130",
+            SenderId: "AIDAIOA2GYWSHW4E2VXIO",
+            ApproximateFirstReceiveTimestamp: "1639777618132",
+          },
+          messageAttributes: {},
+          md5OfBody: "ee19d8b1377919239ad3fd5dabc33739",
+          eventSource: "aws:sqs",
+          eventSourceARN: "arn:aws:sqs:sa-east-1:601427279990:aj-js-library-test-dev-demo-queue",
+          awsRegion: "sa-east-1",
+        },
+      ],
+    });
+    expect(result).toEqual({
+      parentID: "4247550101648618618",
+      sampleMode: 1,
+      source: "event",
+      traceID: "7102291628443134919",
     });
   });
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes https://github.com/DataDog/serverless-plugin-datadog/issues/232

TODO: Bump linked version of dd-trace in this PR

### Motivation

Although AWS documentation claims that string values are supported, AWS support has told us that stuffing JSON into a string is not supported, and breaks filter policies entirely. These messages are not rejected, and are successfully delivered to recipients without a filter policy, so they fail silently.

This change is backwards compatible, so users still relying on DD trace 2.1 can use this version.

### Testing Guidelines

I created a test app that publishes to a topic and contains an SQS subscription with a filter policy. I've verified that these changes combined with my changes in dd trace js (https://github.com/DataDog/dd-trace-js/pull/1889) properly propagate trace context and are not subject to filter policies:

![image](https://user-images.githubusercontent.com/1598537/156413026-ae7a14e3-d0f1-41f7-992f-213b8fd2744e.png)


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
