### PR TITLE
fix: Wrap logError in conditional for isAgentRunning, as this is now the agent's responsibility

### DIFF
--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -181,7 +181,7 @@ export class MetricsListener {
       }
     } else {
       const errorMessage = "api key not configured, see https://dtdg.co/sls-node-metrics";
-      if (config.logForwarding) {
+      if (config.logForwarding || this.isAgentRunning) {
         logDebug(errorMessage);
       } else {
         logError(errorMessage);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Use logDebug instead of logError if the Agent (extension) is running. The API key is required there, not by this library (unless we are using the forwarder and sending metrics to the backend from this library)

### Motivation

Fixes https://github.com/DataDog/serverless-plugin-datadog/issues/237

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
