### PR TITLE
feat: Clean build and copy handler.js

### DIFF
--- a/integration_tests/snapshots/logs/esm_node12.log
+++ b/integration_tests/snapshots/logs/esm_node12.log
@@ -1,18 +1,246 @@
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'esm'\nRequire stack:\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js\n- /opt/nodejs/node_modules/datadog-lambda-js/handler.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'esm'","Require stack:","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js","- /opt/nodejs/node_modules/datadog-lambda-js/handler.js","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at ImportModuleError.ExtendedError [as constructor] (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at new ImportModuleError (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at _loadUserAppSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at loadSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:XXX:XXX)","    at Module._compile (internal/modules/cjs/loader.js:XXX:XXX)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.load (internal/modules/cjs/loader.js:XXX:XXX)","    at Function.Module._load (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.require (internal/modules/cjs/loader.js:XXX:XXX)"]}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "tcp.connect",
+        "resource": "127.0.0.1:9001",
+        "error": 0,
+        "meta": {
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node12",
+          "runtime-id":"XXXX",
+          "tcp.remote.host": "127.0.0.1",
+          "tcp.family": "IPv4",
+          "out.host": "127.0.0.1",
+          "span.kind": "client",
+          "tcp.local.address":"XXXX",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "tcp.remote.port": 9001,
+          "out.port": 9001,
+          "tcp.local.port":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "service": "integration-tests-js-XXXX-esm_node12"
+      }
+    ]
+  ]
+}
 START
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'esm'\nRequire stack:\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js\n- /opt/nodejs/node_modules/datadog-lambda-js/handler.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'esm'","Require stack:","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js","- /opt/nodejs/node_modules/datadog-lambda-js/handler.js","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at ImportModuleError.ExtendedError [as constructor] (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at new ImportModuleError (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at _loadUserAppSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at loadSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:XXX:XXX)","    at Module._compile (internal/modules/cjs/loader.js:XXX:XXX)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.load (internal/modules/cjs/loader.js:XXX:XXX)","    at Function.Module._load (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.require (internal/modules/cjs/loader.js:XXX:XXX)"]}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "tcp.connect",
+        "resource": "127.0.0.1:9001",
+        "error": 0,
+        "meta": {
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node12",
+          "runtime-id":"XXXX",
+          "tcp.remote.host": "127.0.0.1",
+          "tcp.family": "IPv4",
+          "out.host": "127.0.0.1",
+          "span.kind": "client",
+          "tcp.local.address":"XXXX",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "tcp.remote.port": 9001,
+          "out.port": 9001,
+          "tcp.local.port":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "service": "integration-tests-js-XXXX-esm_node12"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms Memory Used: XXXX MB
 Unknown application error occurred
 Runtime.ImportModuleError
 START
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'esm'\nRequire stack:\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js\n- /opt/nodejs/node_modules/datadog-lambda-js/handler.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'esm'","Require stack:","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js","- /opt/nodejs/node_modules/datadog-lambda-js/handler.js","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at ImportModuleError.ExtendedError [as constructor] (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at new ImportModuleError (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at _loadUserAppSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at loadSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:XXX:XXX)","    at Module._compile (internal/modules/cjs/loader.js:XXX:XXX)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.load (internal/modules/cjs/loader.js:XXX:XXX)","    at Function.Module._load (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.require (internal/modules/cjs/loader.js:XXX:XXX)"]}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "tcp.connect",
+        "resource": "127.0.0.1:9001",
+        "error": 0,
+        "meta": {
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node12",
+          "runtime-id":"XXXX",
+          "tcp.remote.host": "127.0.0.1",
+          "tcp.family": "IPv4",
+          "out.host": "127.0.0.1",
+          "span.kind": "client",
+          "tcp.local.address":"XXXX",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "tcp.remote.port": 9001,
+          "out.port": 9001,
+          "tcp.local.port":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "service": "integration-tests-js-XXXX-esm_node12"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms Memory Used: XXXX MB
 Unknown application error occurred
 Runtime.ImportModuleError
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'esm'\nRequire stack:\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js\n- /opt/nodejs/node_modules/datadog-lambda-js/handler.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'esm'","Require stack:","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js","- /opt/nodejs/node_modules/datadog-lambda-js/handler.js","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at ImportModuleError.ExtendedError [as constructor] (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at new ImportModuleError (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at _loadUserAppSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at loadSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:XXX:XXX)","    at Module._compile (internal/modules/cjs/loader.js:XXX:XXX)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.load (internal/modules/cjs/loader.js:XXX:XXX)","    at Function.Module._load (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.require (internal/modules/cjs/loader.js:XXX:XXX)"]}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "tcp.connect",
+        "resource": "127.0.0.1:9001",
+        "error": 0,
+        "meta": {
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node12",
+          "runtime-id":"XXXX",
+          "tcp.remote.host": "127.0.0.1",
+          "tcp.family": "IPv4",
+          "out.host": "127.0.0.1",
+          "span.kind": "client",
+          "tcp.local.address":"XXXX",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "tcp.remote.port": 9001,
+          "out.port": 9001,
+          "tcp.local.port":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "service": "integration-tests-js-XXXX-esm_node12"
+      }
+    ]
+  ]
+}
 START
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'esm'\nRequire stack:\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js\n- /opt/nodejs/node_modules/datadog-lambda-js/handler.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'esm'","Require stack:","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js","- /opt/nodejs/node_modules/datadog-lambda-js/handler.js","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at ImportModuleError.ExtendedError [as constructor] (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at new ImportModuleError (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at _loadUserAppSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at loadSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:XXX:XXX)","    at Module._compile (internal/modules/cjs/loader.js:XXX:XXX)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.load (internal/modules/cjs/loader.js:XXX:XXX)","    at Function.Module._load (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.require (internal/modules/cjs/loader.js:XXX:XXX)"]}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "tcp.connect",
+        "resource": "127.0.0.1:9001",
+        "error": 0,
+        "meta": {
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node12",
+          "runtime-id":"XXXX",
+          "tcp.remote.host": "127.0.0.1",
+          "tcp.family": "IPv4",
+          "out.host": "127.0.0.1",
+          "span.kind": "client",
+          "tcp.local.address":"XXXX",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "tcp.remote.port": 9001,
+          "out.port": 9001,
+          "tcp.local.port":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "service": "integration-tests-js-XXXX-esm_node12"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms Memory Used: XXXX MB
 Unknown application error occurred
 Runtime.ImportModuleError
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	Uncaught Exception 	{"errorType":"Runtime.ImportModuleError","errorMessage":"Error: Cannot find module 'esm'\nRequire stack:\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js\n- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js\n- /opt/nodejs/node_modules/datadog-lambda-js/handler.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js","stack":["Runtime.ImportModuleError: Error: Cannot find module 'esm'","Require stack:","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js","- /opt/nodejs/node_modules/datadog-lambda-js/runtime/index.js","- /opt/nodejs/node_modules/datadog-lambda-js/handler.js","- /var/runtime/UserFunction.js","- /var/runtime/index.js","    at ImportModuleError.ExtendedError [as constructor] (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at new ImportModuleError (/opt/nodejs/node_modules/datadog-lambda-js/runtime/errors.js:XXX:XXX)","    at _loadUserAppSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at loadSync (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:XXX:XXX)","    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:XXX:XXX)","    at Module._compile (internal/modules/cjs/loader.js:XXX:XXX)","    at Object.Module._extensions..js (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.load (internal/modules/cjs/loader.js:XXX:XXX)","    at Function.Module._load (internal/modules/cjs/loader.js:XXX:XXX)","    at Module.require (internal/modules/cjs/loader.js:XXX:XXX)"]}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "tcp.connect",
+        "resource": "127.0.0.1:9001",
+        "error": 0,
+        "meta": {
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node12",
+          "runtime-id":"XXXX",
+          "tcp.remote.host": "127.0.0.1",
+          "tcp.family": "IPv4",
+          "out.host": "127.0.0.1",
+          "span.kind": "client",
+          "tcp.local.address":"XXXX",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "tcp.remote.port": 9001,
+          "out.port": 9001,
+          "tcp.local.port":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "service": "integration-tests-js-XXXX-esm_node12"
+      }
+    ]
+  ]
+}

--- a/integration_tests/snapshots/logs/process-input-traced_node12.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node12.log
@@ -34,6 +34,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "runtime-id":"XXXX",
           "operation_name": "aws.apigateway",
           "resource_names": "GET /{proxy+}",
@@ -47,6 +48,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -168,6 +170,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sns",
           "runtime-id":"XXXX",
           "operation_name": "aws.sns",
@@ -185,6 +188,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -284,6 +288,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sqs",
           "runtime-id":"XXXX",
           "operation_name": "aws.sqs",
@@ -298,6 +303,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "retry_count": 1,
           "_sampling_priority_v1": 1
         },

--- a/integration_tests/snapshots/logs/process-input-traced_node14.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node14.log
@@ -34,6 +34,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "runtime-id":"XXXX",
           "operation_name": "aws.apigateway",
           "resource_names": "GET /{proxy+}",
@@ -47,6 +48,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -168,6 +170,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sns",
           "runtime-id":"XXXX",
           "operation_name": "aws.sns",
@@ -185,6 +188,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -284,6 +288,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sqs",
           "runtime-id":"XXXX",
           "operation_name": "aws.sqs",
@@ -298,6 +303,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "retry_count": 1,
           "_sampling_priority_v1": 1
         },

--- a/integration_tests/snapshots/logs/process-input-traced_node16.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node16.log
@@ -34,6 +34,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "version": "1.0.0",
           "runtime-id":"XXXX",
           "operation_name": "aws.apigateway",
@@ -48,6 +49,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -172,6 +174,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sns",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -190,6 +193,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -291,6 +295,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sqs",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -306,6 +311,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "retry_count": 1,
           "_sampling_priority_v1": 1
         },

--- a/integration_tests/snapshots/logs/status-code-500s_node12.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node12.log
@@ -40,6 +40,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "runtime-id":"XXXX",
           "operation_name": "aws.apigateway",
           "resource_names": "GET /{proxy+}",
@@ -53,6 +54,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -121,6 +123,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sns",
           "runtime-id":"XXXX",
           "operation_name": "aws.sns",
@@ -138,6 +141,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -205,6 +209,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sqs",
           "runtime-id":"XXXX",
           "operation_name": "aws.sqs",
@@ -219,6 +224,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "retry_count": 1,
           "_sampling_priority_v1": 1
         },

--- a/integration_tests/snapshots/logs/status-code-500s_node14.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node14.log
@@ -40,6 +40,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "runtime-id":"XXXX",
           "operation_name": "aws.apigateway",
           "resource_names": "GET /{proxy+}",
@@ -53,6 +54,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -121,6 +123,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sns",
           "runtime-id":"XXXX",
           "operation_name": "aws.sns",
@@ -138,6 +141,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -205,6 +209,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sqs",
           "runtime-id":"XXXX",
           "operation_name": "aws.sqs",
@@ -219,6 +224,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "retry_count": 1,
           "_sampling_priority_v1": 1
         },

--- a/integration_tests/snapshots/logs/status-code-500s_node16.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node16.log
@@ -40,6 +40,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "version": "1.0.0",
           "runtime-id":"XXXX",
           "operation_name": "aws.apigateway",
@@ -54,6 +55,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -123,6 +125,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sns",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -141,6 +144,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
         "start":XXXX,
@@ -209,6 +213,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.dm": "-0",
           "service": "sqs",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -224,6 +229,7 @@ START
         },
         "metrics": {
           "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
           "retry_count": 1,
           "_sampling_priority_v1": 1
         },

--- a/integration_tests/snapshots/logs/throw-error-traced_node12.log
+++ b/integration_tests/snapshots/logs/throw-error-traced_node12.log
@@ -65,6 +65,7 @@ START
 XXXX-XX-XX XX:XX:XX.XXX	ERROR	[dd.trace_id=XXXX dd.span_id=XXXX] Invoke Error 	{"errorType":"Error","errorMessage":"Hello","stack":["Error: Hello","    at handle (/var/task/throw-error-traced.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/utils/handler.js:XXX:XXX","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at step (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at Object.next (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at new Promise (<anonymous>)","    at __awaiter (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX"]}
 END Duration: XXXX ms Memory Used: XXXX MB
 START
+XXXX-XX-XX XX:XX:XX.XXX	ERROR	[dd.trace_id=XXXX dd.span_id=XXXX] Invoke Error 	{"errorType":"Error","errorMessage":"Hello","stack":["Error: Hello","    at handle (/var/task/throw-error-traced.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/utils/handler.js:XXX:XXX","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at step (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at Object.next (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at new Promise (<anonymous>)","    at __awaiter (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX"]}
 {
   "e": XXXX,
   "m": "aws.lambda.enhanced.invocations",
@@ -95,5 +96,4 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	ERROR	[dd.trace_id=XXXX dd.span_id=XXXX] Invoke Error 	{"errorType":"Error","errorMessage":"Hello","stack":["Error: Hello","    at handle (/var/task/throw-error-traced.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/utils/handler.js:XXX:XXX","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at step (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at Object.next (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at new Promise (<anonymous>)","    at __awaiter (/opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX)","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX","    at /opt/nodejs/node_modules/datadog-lambda-js/index.js:XXX:XXX"]}
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -76,7 +76,11 @@ if [ "$CONT" != "y" ]; then
 fi
 
 echo 'Publishing to NPM'
+if [ -d "./dist" ]; then
+    rm -rf ./dist
+fi
 yarn build
+cp ./dist/handler.cjs ./dist/handler.js
 yarn publish --new-version "$NEW_VERSION"
 
 echo

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,7 +324,7 @@
     source-map "^0.7.3"
     split "^1.0.1"
 
-"@datadog/sketches-js@^2.0.0":
+"@datadog/sketches-js@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.0.tgz#8c7e8028a5fc22ad102fa542b0a446c956830455"
   integrity sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==
@@ -867,6 +867,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1099,6 +1104,13 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
   integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
 
+cidr-matcher@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cidr-matcher/-/cidr-matcher-2.1.1.tgz#01a489f291bfbc7a3a14358120a6d839a98b1c90"
+  integrity sha512-QPJRz4HDQxpB8AZWEqd6ejVp+siArXh3u1MYaUFV85cd293StGSMb87jVe0z9gS92KsFwxCxjb3utO3e5HKHTw==
+  dependencies:
+    ip6addr "^0.2.2"
+
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
@@ -1171,6 +1183,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1211,20 +1228,22 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dd-trace@^2.10.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-2.13.0.tgz#afd7bd775bac34ffd9464e54ac6a701a14834b89"
-  integrity sha512-oy98vzQPYYWyNI63cy7DWpbQdhShvrkDkaWztDE+YFpNVKEfRiRXHYtVtyYOuXxEH5RNtcyck5IZuwfxSEOaeA==
+dd-trace@^2.14.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-2.15.0.tgz#f0ce91a258c0b939763d8d1b8d0eda751e4c1423"
+  integrity sha512-8vNXcurABjhuY4OuMYC1dbbdMmmpsBxiYclHfuyVrNZ62/62LS0KbC7w7XdNvgRZD4oqKHFhDiSFfxKYfpLddg==
   dependencies:
     "@datadog/native-appsec" "^1.2.1"
     "@datadog/native-metrics" "^1.4.2"
     "@datadog/pprof" "^1.0.2"
-    "@datadog/sketches-js" "^2.0.0"
+    "@datadog/sketches-js" "^2.1.0"
     "@types/node" ">=12"
+    cidr-matcher "^2.1.1"
     crypto-randomuuid "^1.0.0"
     diagnostics_channel "^1.1.0"
     ignore "^5.2.0"
-    import-in-the-middle "^1.3.0"
+    import-in-the-middle "^1.3.1"
+    istanbul-lib-coverage "3.2.0"
     koalas "^1.0.2"
     limiter "^1.1.4"
     lodash.kebabcase "^4.1.1"
@@ -1461,6 +1480,16 @@ expect@^27.5.1:
     jest-get-type "^27.5.1"
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -1720,10 +1749,10 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-import-in-the-middle@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.3.0.tgz#314983e57887013a9c32b90ce5625a6871d71798"
-  integrity sha512-esDCEWyzzg0bGShz1N5ybRrPIJFvKaJ7TfTaIFP1XovxFo98In2GiDpOR/Cn/8J1cfRO8i/RrQToQ9j0WL2b0Q==
+import-in-the-middle@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.3.2.tgz#9fa2ae10248ffb37530d29eed76cff62c7ae017d"
+  integrity sha512-TW2Zor1MmNL2e051F+B9pK3fPqMWUSBXzWjcJqfb1VBJgB+89OBh2n2rj3c16EGYeDJpt4eBdrOnrjAIR/6oRA==
   dependencies:
     module-details-from-path "^1.0.3"
 
@@ -1761,6 +1790,14 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ip6addr@^0.2.2:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/ip6addr/-/ip6addr-0.2.5.tgz#06e134f44b4e1a684fd91b24035dca7a53b8f759"
+  integrity sha512-9RGGSB6Zc9Ox5DpDGFnJdIeF0AsqXzdH+FspCfPPaU/L/4tI6P+5lIoFUFm9JXs9IrJv1boqAaNCQmoDADTSKQ==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^2.0.2"
 
 is-arguments@^1.0.4:
   version "1.1.1"
@@ -1915,7 +1952,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@3.2.0, istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
   integrity sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==
@@ -2438,6 +2475,11 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -2447,6 +2489,16 @@ json5@2.x, json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
+jsprim@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
+  integrity sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.4.0"
+    verror "1.10.0"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -3463,6 +3515,15 @@ v8-to-istanbul@^8.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Removes a local dist directory if it exists, and then copies the cjs handler to be just a regular `handler.js`, which was removed in 6.76 (but phantom-published until 6.82, as yarn doesn't perform clean builds)

closes #305 

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
