### PR TITLE
[bugfix] fix lazy load metrics listener  commit: 47c5508488eb67f6a5cdf5c25a73e…

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -12,7 +12,9 @@ import {
 import { incrementErrorsMetric, incrementInvocationsMetric } from "./metrics/enhanced-metrics";
 import { LogLevel, setLogLevel } from "./utils";
 import mock from "mock-fs";
+import * as extPath from "./utils/extension-path";
 
+jest.spyOn(extPath, "isExtensionEnabled").mockReturnValue(true);
 jest.mock("./metrics/enhanced-metrics");
 
 const mockedIncrementErrors = incrementErrorsMetric as jest.Mock<typeof incrementErrorsMetric>;
@@ -49,7 +51,6 @@ describe("datadog", () => {
     oldEnv = process.env;
     process.env = { ...oldEnv };
     nock.cleanAll();
-
     mockedIncrementErrors.mockClear();
     mockedIncrementInvocations.mockClear();
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -14,7 +14,7 @@ import { LogLevel, setLogLevel } from "./utils";
 import mock from "mock-fs";
 import * as extPath from "./utils/extension-path";
 
-jest.spyOn(extPath, "isExtensionEnabled").mockReturnValue(true);
+jest.spyOn(extPath, "isExtensionEnabled").mockReturnValue(false);
 jest.mock("./metrics/enhanced-metrics");
 
 const mockedIncrementErrors = incrementErrorsMetric as jest.Mock<typeof incrementErrorsMetric>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export function datadog<TEvent, TResult>(
   let metricsListener: MetricsListenerType;
   let incrementErrorsMetric: any;
   let incrementInvocationsMetric: any;
-  if (isExtensionEnabled()) {
+  if (!isExtensionEnabled()) {
     const {
       MetricsListener,
       KMSService,

--- a/src/utils/extension-path.ts
+++ b/src/utils/extension-path.ts
@@ -1,5 +1,17 @@
+import { existsSync } from "fs";
 const EXTENSION_PATH = "/opt/extensions/datadog-agent";
+let isExtension: boolean;
 
 export function getExtensionPath() {
   return EXTENSION_PATH;
+}
+
+export function isExtensionEnabled(): boolean {
+  if (isExtension !== undefined) {
+    return isExtension;
+  }
+
+  const extensionPath = getExtensionPath();
+  isExtension = existsSync(extensionPath);
+  return isExtension;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Use `currentTraceListener` and `currentMetricsListener` and only use when they exist.
- Move the `isExtensionEnabled` function to `utils/extension-path`.


### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
