### PR TITLE
Revert "Lazy load metrics listener  (#320)"

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -11,7 +11,6 @@ import {
 } from "./index";
 import { incrementErrorsMetric, incrementInvocationsMetric } from "./metrics/enhanced-metrics";
 import { LogLevel, setLogLevel } from "./utils";
-import mock from "mock-fs";
 
 jest.mock("./metrics/enhanced-metrics");
 
@@ -318,27 +317,6 @@ describe("datadog", () => {
 
     expect(mockedIncrementInvocations).toBeCalledTimes(0);
     expect(mockedIncrementErrors).toBeCalledTimes(0);
-  });
-
-  it("doesn't increment enhanced metrics when using extension", async () => {
-    process.env.DD_ENHANCED_METRICS = "false";
-    mock({
-      "/opt/extensions/datadog-agent": Buffer.from([0]),
-    });
-
-    const handlerError: Handler = (event, context, callback) => {
-      throw Error("Some error");
-    };
-
-    const wrappedHandler = datadog(handlerError, { forceWrap: true });
-
-    const result = wrappedHandler({}, mockContext, () => {});
-    await expect(result).rejects.toEqual(Error("Some error"));
-
-    expect(mockedIncrementInvocations).toBeCalledTimes(0);
-    expect(mockedIncrementErrors).toBeCalledTimes(0);
-
-    mock.restore();
   });
 
   it("use custom logger to log debug messages", async () => {

--- a/src/metrics/extension.ts
+++ b/src/metrics/extension.ts
@@ -1,16 +1,15 @@
 import { URL } from "url";
 import { get, post, logDebug, logError } from "../utils";
-import { getExtensionPath } from "../utils/extension-path";
 import fs from "fs";
 
 export const AGENT_URL = "http://127.0.0.1:8124";
 const HELLO_PATH = "/lambda/hello";
 const FLUSH_PATH = "/lambda/flush";
+const EXTENSION_PATH = "/opt/extensions/datadog-agent";
 const AGENT_TIMEOUT_MS = 100;
 
 export async function isAgentRunning() {
-  const extensionPath = getExtensionPath();
-  const extensionExists = await fileExists(extensionPath);
+  const extensionExists = await fileExists(EXTENSION_PATH);
   if (!extensionExists) {
     logDebug(`Agent isn't present in sandbox`);
     return false;

--- a/src/utils/extension-path.ts
+++ b/src/utils/extension-path.ts
@@ -1,5 +1,0 @@
-const EXTENSION_PATH = "/opt/extensions/datadog-agent";
-
-export function getExtensionPath() {
-  return EXTENSION_PATH;
-}


### PR DESCRIPTION
This reverts commit 47c5508488eb67f6a5cdf5c25a73e4971edf02f9.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Revert the commit 47c55084 as it is causing the metrics and traces not sent.
The tests done for the original commit 47c55084 was not correctly setup and caused confusion.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
