### PR TITLE
feat: Move end span after children finish

### DIFF
--- a/src/trace/cold-start-tracer.ts
+++ b/src/trace/cold-start-tracer.ts
@@ -92,11 +92,11 @@ export class ColdStartTracer {
       this.tracerWrapper.startSpan(this.coldStartSpanOperationName(reqNode.filename), options),
       {},
     );
-    newSpan?.finish(reqNode.endTime);
     if (reqNode.endTime - reqNode.startTime > this.minDuration) {
       for (const node of reqNode.children || []) {
         this.traceTree(node, newSpan);
       }
     }
+    newSpan?.finish(reqNode.endTime);
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

In theory the tracer will flush when all spans finish. I moved this just before merging this feature, but now think it best to move it back to my original location - after child nodes have been traced.

### Motivation

Just in case, this should prevent us from attempting to flush after every module load span is created.

### Testing Guidelines

Units and integration tests passing should suffice here.

### Additional Notes

No

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
