### PR TITLE
Fix disabling of cold start tracing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,9 +86,10 @@ export const defaultConfig: Config = {
 let currentMetricsListener: MetricsListener | undefined;
 let currentTraceListener: TraceListener | undefined;
 
-if (getEnvValue(coldStartTracingEnvVar, "true")) {
+if (getEnvValue(coldStartTracingEnvVar, "true").toLowerCase() === "true") {
   subscribeToDC();
 }
+
 /**
  * Wraps your AWS lambda handler functions to add tracing/metrics support
  * @param handler A lambda handler function.


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Fixes so that cold start tracing can be disabled as documented.

The value from getEnvValue is a string, and unless this is a blank string it will always be truthy, even when the value is "false".

Use the similar pattern as used in the config section.

### Motivation

<!--- What inspired you to submit this pull request? --->

I've tested out provisioned concurrency, but this makes tracing very inconvenient to use as it might generate traces that lasts for a very long time (so a 50 ms lambda might show a trace for 1h+). I wanted to disable cold start tracing to avoid those cases.

Ideally, maybe cold starts outside an invocation (as for provisioned concurrency), should not be included by default, but cold starts that took place during an invocation should be included.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
