### PR TITLE
fix: drop node12.x from publish script

### DIFF
--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -10,7 +10,7 @@
 # VERSION is required.
 set -e
 
-NODE_VERSIONS_FOR_AWS_CLI=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x")
+NODE_VERSIONS_FOR_AWS_CLI=("nodejs14.x" "nodejs16.x" "nodejs18.x")
 LAYER_PATHS=(".layers/datadog_lambda_node14.15.zip" ".layers/datadog_lambda_node16.14.zip" ".layers/datadog_lambda_node18.12.zip")
 AVAILABLE_LAYERS=("Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Unfortunately this caused an off by one error where we'd apply the wrong `compatible-runtime` flag to published layers.
<img width="516" alt="image" src="https://user-images.githubusercontent.com/1598537/230934008-2239b7dc-03f6-4344-b02f-7495ca5fc442.png">

Fortunately this flag is not actually enforced in Lambda, and is a label only. So this has no runtime implications.

Searching the `publish_layers` codebase, we see this is only used for setting this flag.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
