### PR TITLE
feat: Strip prebuilds except linux x86/arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,12 @@ RUN rm -rf /nodejs/node_modules/@datadog/native-metrics
 RUN rm -rf /nodejs/node_modules/hdr-histogram-js/build
 RUN rm -rf /nodejs/node_modules/protobufjs/dist
 RUN rm -rf /nodejs/node_modules/protobufjs/cli
+RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/linux-arm
+RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/linuxmusl-x64
+RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/darwin-arm64
+RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/darwin-x64
+RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/win32-ia32
+RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/win32-x64
 RUN rm -rf /nodejs/node_modules/@datadog/native-iast-taint-tracking
 RUN rm -rf /nodejs/node_modules/@datadog/native-iast-rewriter
 RUN find /nodejs/node_modules -name "*.d.ts" -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN rm -rf /nodejs/node_modules/hdr-histogram-js/build
 RUN rm -rf /nodejs/node_modules/protobufjs/dist
 RUN rm -rf /nodejs/node_modules/protobufjs/cli
 RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/linux-arm
-RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/linuxmusl-x64
 RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/darwin-arm64
 RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/darwin-x64
 RUN rm -rf /nodejs/node_modules/@datadog/pprof/prebuilds/win32-ia32


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

We've recently expanded the prebuilt profilers from a handful [to several additional prebuilt binaries](https://github.com/DataDog/pprof-nodejs). This has taken a bunch of space, but we only need two prebuilds:
- Linux x86
- Linux arm64

This change strips the rest of the prebuilds out.

Using Cold Start Tracing, I verified that the profiler is still loaded in both x86:
<img width="957" alt="Screenshot 2023-04-11 at 9 27 03 AM" src="https://user-images.githubusercontent.com/1598537/231181717-669153ac-cbc8-494e-a07d-c1abd2f1ced5.png">

And in arm64:
<img width="966" alt="Screenshot 2023-04-11 at 9 31 40 AM" src="https://user-images.githubusercontent.com/1598537/231181780-2f3462cc-587c-4e39-8e82-186deceb6261.png">

And I verified profiles are still being created properly:
<img width="1207" alt="Screenshot 2023-04-11 at 9 35 01 AM" src="https://user-images.githubusercontent.com/1598537/231181852-abd5dac3-7883-4ab0-b22c-4a1204f56e28.png">

This saves about 9mb, with the RC on the left, and the latest version 89 on the right:
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/1598537/231181221-7ca30272-ce5a-4061-b959-f0a719e66c6d.png">

### Motivation

Performance and binary size reduction

### Testing Guidelines

I enabled profiling for both x86 and arm functions and verified they are both working.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
