### PR TITLE
feat: Support async trace context extraction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export function datadog<TEvent, TResult>(
     currentTraceListener = traceListener;
 
     try {
-      traceListener.onStartInvocation(event, context);
+      await traceListener.onStartInvocation(event, context);
       await metricsListener.onStartInvocation(event);
       if (finalConfig.enhancedMetrics) {
         incrementInvocationsMetric(metricsListener, context);

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -102,17 +102,17 @@ export function deterministicMd5HashToBigIntString(s: string): string {
  * Reads the trace context from either an incoming lambda event, or the current xray segment.
  * @param event An incoming lambda event. This must have incoming trace headers in order to be read.
  */
-export function extractTraceContext(
+export async function extractTraceContext(
   event: any,
   context: Context,
   extractor?: TraceExtractor,
   decodeAuthorizerContext: boolean = true,
-): TraceContext | undefined {
+): Promise<TraceContext | undefined> {
   let trace;
 
   if (extractor) {
     try {
-      trace = extractor(event, context);
+      trace = await extractor(event, context);
       logDebug(`extracted trace context from the custom extractor`, { trace });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -106,7 +106,7 @@ describe("TraceListener", () => {
 
   it("wraps dd-trace span around invocation", async () => {
     const listener = new TraceListener(defaultConfig);
-    listener.onStartInvocation({}, context as any);
+    await listener.onStartInvocation({}, context as any);
     const unwrappedFunc = () => {};
     const wrappedFunc = listener.onWrap(unwrappedFunc);
     wrappedFunc();
@@ -141,7 +141,7 @@ describe("TraceListener", () => {
       "x-datadog-trace-id": "4110911582297405551",
     };
     mockTraceSource = Source.Event;
-    listener.onStartInvocation({}, context as any);
+    await listener.onStartInvocation({}, context as any);
     const unwrappedFunc = () => {};
     const wrappedFunc = listener.onWrap(unwrappedFunc);
     wrappedFunc();
@@ -179,7 +179,7 @@ describe("TraceListener", () => {
     };
     mockTraceSource = Source.Xray;
 
-    listener.onStartInvocation({}, context as any);
+    await listener.onStartInvocation({}, context as any);
     const unwrappedFunc = () => {};
     const wrappedFunc = listener.onWrap(unwrappedFunc);
     wrappedFunc();
@@ -215,7 +215,7 @@ describe("TraceListener", () => {
     };
     mockTraceSource = Source.Xray;
 
-    listener.onStartInvocation({}, context as any);
+    await listener.onStartInvocation({}, context as any);
     const unwrappedFunc = () => {};
     const wrappedFunc = listener.onWrap(unwrappedFunc);
     wrappedFunc();
@@ -246,7 +246,7 @@ describe("TraceListener", () => {
 
   it("wraps dd-trace span around invocation, with function alias", async () => {
     const listener = new TraceListener(defaultConfig);
-    listener.onStartInvocation({}, contextWithFunctionAlias as any);
+    await listener.onStartInvocation({}, contextWithFunctionAlias as any);
     const unwrappedFunc = () => {};
     const wrappedFunc = listener.onWrap(unwrappedFunc);
     wrappedFunc();
@@ -275,7 +275,7 @@ describe("TraceListener", () => {
 
   it("wraps dd-trace span around invocation, with function version", async () => {
     const listener = new TraceListener(defaultConfig);
-    listener.onStartInvocation({}, contextWithFunctionVersion as any);
+    await listener.onStartInvocation({}, contextWithFunctionVersion as any);
     const unwrappedFunc = () => {};
     const wrappedFunc = listener.onWrap(unwrappedFunc);
     wrappedFunc();

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -20,7 +20,7 @@ import { SpanContext, TraceOptions, TracerWrapper } from "./tracer-wrapper";
 import { SpanInferrer } from "./span-inferrer";
 import { SpanWrapper } from "./span-wrapper";
 import { getTraceTree } from "../runtime/index";
-export type TraceExtractor = (event: any, context: Context) => TraceContext;
+export type TraceExtractor = (event: any, context: Context) => Promise<TraceContext> | TraceContext;
 
 export interface TraceConfig {
   /**
@@ -88,7 +88,7 @@ export class TraceListener {
     this.inferrer = new SpanInferrer(this.tracerWrapper);
   }
 
-  public onStartInvocation(event: any, context: Context) {
+  public async onStartInvocation(event: any, context: Context) {
     const tracerInitialized = this.tracerWrapper.isTracerAvailable;
     if (this.config.injectLogContext) {
       patchConsole(console, this.contextService);
@@ -104,7 +104,7 @@ export class TraceListener {
     } else {
       logDebug("Not patching HTTP libraries", { autoPatchHTTP: this.config.autoPatchHTTP, tracerInitialized });
     }
-    const rootTraceHeaders = this.contextService.extractHeadersFromContext(
+    const rootTraceHeaders = await this.contextService.extractHeadersFromContext(
       event,
       context,
       this.config.traceExtractor,

--- a/src/trace/trace-context-service.ts
+++ b/src/trace/trace-context-service.ts
@@ -21,13 +21,13 @@ export class TraceContextService {
 
   constructor(private tracerWrapper: TracerWrapper) {}
 
-  extractHeadersFromContext(
+  async extractHeadersFromContext(
     event: any,
     context: Context,
     extractor?: TraceExtractor,
     decodeAuthorizerContext: boolean = true,
-  ): Partial<TraceHeaders> | undefined {
-    this.rootTraceContext = extractTraceContext(event, context, extractor, decodeAuthorizerContext);
+  ): Promise<Partial<TraceHeaders> | undefined> {
+    this.rootTraceContext = await extractTraceContext(event, context, extractor, decodeAuthorizerContext);
     return this.currentTraceHeaders;
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR permits a custom trace context extractor to be asynchronous

### Motivation
Fixes #385

### Testing Guidelines
I added a new unit test to cover the async path, and repurposed an existing test to cover the synchronous path.

### Additional Notes
I tested this manually by requesting `datadoghq.com` in an async extractor
```js
module.exports.json = async (payload) => {
  const res = await axios.get('https://datadoghq.com');
  console.log('GOT RES IN ASYNC HANDLER:', res);
  return;
};
```

We can see that the call was awaited and the result returned, even though the extractor returned null, the logged result from [this line](https://github.com/DataDog/datadog-lambda-js/blob/main/src/trace/context.ts#L116) is shown after the request finished:
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/1598537/235937013-8f47feb2-0051-4ca3-9ed5-ca732534929d.png">

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
