### PR TITLE
fix: `tagObject` to avoid ignoring booleans

### DIFF
--- a/src/utils/tag-object.spec.ts
+++ b/src/utils/tag-object.spec.ts
@@ -22,9 +22,11 @@ describe("tagObject", () => {
         keyOne: "foobar",
         myObject: {
           anotherKey: ["array", "of", "values"],
+          nestedBoolean: false
         },
         val: null,
         number: 1,
+        aBoolean: true
       },
     });
     expect(setTag.mock.calls).toEqual([
@@ -32,8 +34,10 @@ describe("tagObject", () => {
       ["lambda_payload.request.myObject.anotherKey.0", "array"],
       ["lambda_payload.request.myObject.anotherKey.1", "of"],
       ["lambda_payload.request.myObject.anotherKey.2", "values"],
+      ["lambda_payload.request.myObject.nestedBoolean", false],
       ["lambda_payload.request.val", null],
       ["lambda_payload.request.number", 1],
+      ["lambda_payload.request.aBoolean", true],
     ]);
   });
   it("tags arrays of objects", () => {

--- a/src/utils/tag-object.spec.ts
+++ b/src/utils/tag-object.spec.ts
@@ -22,11 +22,11 @@ describe("tagObject", () => {
         keyOne: "foobar",
         myObject: {
           anotherKey: ["array", "of", "values"],
-          nestedBoolean: false
+          nestedBoolean: false,
         },
         val: null,
         number: 1,
-        aBoolean: true
+        aBoolean: true,
       },
     });
     expect(setTag.mock.calls).toEqual([

--- a/src/utils/tag-object.ts
+++ b/src/utils/tag-object.ts
@@ -20,7 +20,7 @@ export function tagObject(currentSpan: any, key: string, obj: any, depth = 0): a
     }
     return tagObject(currentSpan, key, parsed, depth);
   }
-  if (typeof obj === "number") {
+  if (typeof obj === "number" || typeof obj === "boolean") {
     return currentSpan.setTag(key, obj);
   }
   if (typeof obj === "object") {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates `tagObject.ts` to avoid ignoring booleans.

### Motivation

Since booleans were not considered in this function, they would be avoided and they will not shown in Datadog when opting in for AWS Lambda payload capture.

### Testing Guidelines

Updated existing test to use booleans.

### Additional Notes

n/a

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
