### PR TITLE
Pass tracer explicitly to datadog wrapper to avoid side effects when

### DIFF
--- a/src/handler.cjs
+++ b/src/handler.cjs
@@ -7,15 +7,17 @@ const {
 } = require("./index.js");
 const { logDebug, logError } = require("./utils/index.js");
 const { loadSync } = require("./runtime/index.js");
-const { initTracer } = require("./runtime/module_importer");
+const { loadTracer } = require("./runtime/module_importer.js");
+const { initTracer } = require("./trace/index.js");
 
 if (process.env.DD_TRACE_DISABLED_PLUGINS === undefined) {
   process.env.DD_TRACE_DISABLED_PLUGINS = "fs";
   logDebug("disabled the dd-trace plugin 'fs'");
 }
 
+const tracer = loadTracer();
 if (getEnvValue("DD_TRACE_ENABLED", "true").toLowerCase() === "true") {
-  initTracer();
+  initTracer(tracer);
 }
 
 const taskRootEnv = getEnvValue(lambdaTaskRootEnvVar, "");
@@ -32,4 +34,4 @@ if (extractorEnv) {
   }
 }
 
-exports.handler = datadog(loadSync(taskRootEnv, handlerEnv), { traceExtractor });
+exports.handler = datadog(loadSync(taskRootEnv, handlerEnv), tracer, { traceExtractor });

--- a/src/handler.mjs
+++ b/src/handler.mjs
@@ -1,15 +1,17 @@
 import { datadog, datadogHandlerEnvVar, lambdaTaskRootEnvVar, traceExtractorEnvVar, getEnvValue } from "./index.js";
 import { logDebug, logError } from "./utils/index.js";
 import { load } from "./runtime/index.js";
-import { initTracer } from "./runtime/module_importer.js";
+import { loadTracer } from "./runtime/module_importer.js";
+import { initTracer } from "./trace/index.js";
 
 if (process.env.DD_TRACE_DISABLED_PLUGINS === undefined) {
   process.env.DD_TRACE_DISABLED_PLUGINS = "fs";
   logDebug("disabled the dd-trace plugin 'fs'");
 }
 
+const tracer = loadTracer();
 if (getEnvValue("DD_TRACE_ENABLED", "true").toLowerCase() === "true") {
-  initTracer();
+  initTracer(tracer);
 }
 
 const taskRootEnv = getEnvValue(lambdaTaskRootEnvVar, "");
@@ -26,4 +28,4 @@ if (extractorEnv) {
   }
 }
 
-export const handler = datadog(await load(taskRootEnv, handlerEnv), { traceExtractor });
+export const handler = datadog(await load(taskRootEnv, handlerEnv), tracer, { traceExtractor });

--- a/src/runtime/module_importer.js
+++ b/src/runtime/module_importer.js
@@ -7,21 +7,17 @@ exports.import = function (path) {
     return import(path);
 }
 
-exports.initTracer = function () {
-    // Looks for the function local version of dd-trace first, before using
-    // the version provided by the layer
-    const path = require.resolve("dd-trace", { paths: ["/var/task/node_modules", ...module.paths] });
-    // tslint:disable-next-line:no-var-requires
-    const tracer = require(path).init({
-        tags: {
-            "_dd.origin": "lambda",
-        },
-    });
-    logDebug("automatically initialized dd-trace");
-
-    // Configure the tracer to ignore HTTP calls made from the Lambda Library to the Extension
-    tracer.use("http", {
-        blocklist: /:8124\/lambda/,
-    });
-    return tracer;
+exports.loadTracer = function () {
+    try {
+        // Looks for the function local version of dd-trace first, before using
+        // the version provided by the layer
+        const path = require.resolve("dd-trace", { paths: ["/var/task/node_modules", ...module.paths] });
+        // tslint:disable-next-line:no-var-requires
+        return require(path);
+    } catch (err) {
+        if (err instanceof Object || err instanceof Error) {
+            logDebug("Couldn't require dd-trace from main", err);
+        }
+    }
+    return undefined;
 }

--- a/src/trace/cold-start-tracer.spec.ts
+++ b/src/trace/cold-start-tracer.spec.ts
@@ -2,9 +2,12 @@ import { RequireNode } from "../runtime/require-tracer";
 import { ColdStartTracerConfig, ColdStartTracer } from "./cold-start-tracer";
 import { TracerWrapper, SpanOptions } from "./tracer-wrapper";
 import { SpanWrapper } from "./span-wrapper";
+import { loadTracer } from "../runtime/module_importer.js";
 
 let mockStartSpan: jest.Mock<any, any>;
 let mockFinishSpan: jest.Mock<any, any>;
+
+const tracer = loadTracer();
 
 jest.mock("./tracer-wrapper", () => {
   mockFinishSpan = jest.fn();
@@ -63,7 +66,7 @@ describe("ColdStartTracer", () => {
       } as any as RequireNode,
     ];
     const coldStartConfig: ColdStartTracerConfig = {
-      tracerWrapper: new TracerWrapper(),
+      tracerWrapper: new TracerWrapper(tracer),
       parentSpan: {
         span: {},
         name: "my-lambda-span",
@@ -154,7 +157,7 @@ describe("ColdStartTracer", () => {
       } as any as RequireNode,
     ];
     const coldStartConfig: ColdStartTracerConfig = {
-      tracerWrapper: new TracerWrapper(),
+      tracerWrapper: new TracerWrapper(tracer),
       parentSpan: {
         span: {},
         name: "my-lambda-span",

--- a/src/trace/index.ts
+++ b/src/trace/index.ts
@@ -1,2 +1,3 @@
 export { TraceConfig, TraceListener, TraceExtractor } from "./listener";
 export { TraceHeaders } from "./trace-context-service";
+export { initTracer } from "./tracer-wrapper";

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -20,6 +20,7 @@ import { SpanContext, TraceOptions, TracerWrapper } from "./tracer-wrapper";
 import { SpanInferrer } from "./span-inferrer";
 import { SpanWrapper } from "./span-wrapper";
 import { getTraceTree, clearTraceTree } from "../runtime/index";
+import { Tracer } from "dd-trace";
 export type TraceExtractor = (event: any, context: Context) => Promise<TraceContext> | TraceContext;
 
 export interface TraceConfig {
@@ -82,8 +83,8 @@ export class TraceListener {
     return this.contextService.currentTraceHeaders;
   }
 
-  constructor(private config: TraceConfig) {
-    this.tracerWrapper = new TracerWrapper();
+  constructor(private readonly tracer: Tracer, private config: TraceConfig) {
+    this.tracerWrapper = new TracerWrapper(tracer);
     this.contextService = new TraceContextService(this.tracerWrapper);
     this.inferrer = new SpanInferrer(this.tracerWrapper);
   }

--- a/src/trace/tracer-wrapper.spec.ts
+++ b/src/trace/tracer-wrapper.spec.ts
@@ -1,5 +1,6 @@
 import { TracerWrapper } from "./tracer-wrapper";
 import { Source, SampleMode } from "./constants";
+import { loadTracer } from "../runtime/module_importer.js";
 
 let mockNoTracer = false;
 let mockTracerInitialised = false;
@@ -35,27 +36,32 @@ describe("TracerWrapper", () => {
     delete process.env["AWS_LAMBDA_FUNCTION_NAME"];
   });
   it("isTracerAvailable should return true when dd-trace is present and initialised", () => {
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     expect(wrapper.isTracerAvailable).toBeTruthy();
   });
   it("isTracerAvailable should return false when dd-trace is present and uninitialised", () => {
     mockNoTracer = false;
     mockTracerInitialised = false;
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     expect(wrapper.isTracerAvailable).toBeFalsy();
   });
   it("isTracerAvailable should return false when dd-trace is absent", () => {
     mockNoTracer = true;
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     expect(wrapper.isTracerAvailable).toBeFalsy();
   });
   it("should extract span context when dd-trace is present", () => {
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     expect(wrapper.extract({})).toBe(mockSpanContext);
   });
   it("shouldn't extract span context when dd-trace is absent", () => {
     mockNoTracer = true;
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     expect(wrapper.extract({})).toBeNull();
   });
 
@@ -69,7 +75,8 @@ describe("TracerWrapper", () => {
         toTraceId: () => traceID,
       }),
     };
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     const traceContext = wrapper.traceContext();
     expect(traceContext).toEqual({
       parentID: spanID,
@@ -79,7 +86,8 @@ describe("TracerWrapper", () => {
     });
   });
   it("should return undefined when no span is available", () => {
-    const wrapper = new TracerWrapper();
+    const tracer = loadTracer();
+    const wrapper = new TracerWrapper(tracer);
     const traceContext = wrapper.traceContext();
     expect(traceContext).toBeUndefined();
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "es2020.bigint"
     ]
     /* Specify library files to be included in the compilation. */,
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The tracer is passed explicitly to `datadog` wrapper. This reduces the dynamic resolution of `dd-trace` to a single place, and resolves the following issue:

Assume that you use the libraries `dd-trace` and `datadog-lambda-js` as npm modules without the layer. Moreover, assume you use a bundler like `esbuild`. In this situation, when initializing the trace as follows

```
import { tracer } from "dd-trace"
tracer.init(...)

export handler = datadog(handler_to_be_wrapped, ...)
```

and bundling this code with `esbuild` say

```
esbuild.build({
    entryPoints: [above_file],
    bundle: true,
    treeShaking: true,
    minify: true,
    sourcemap: true,
    entryNames: "[name]/index",
    outdir: "dist",
    platform: "node",
    target: ["node18"],
    logLevel: "info",
    plugins: [require("dd-trace/esbuild")],
})
```

the trace initialized will not be the same as the one this library loads, resulting in using a noop tracer for calls within this library. Up to my knowledge, there is no possibility to resolve this issue otherwise.

For the layer case, this change will not have an impact. However, the `datadog` wrapper has now a mandatory additional attribute. Thus, this change is potentially a breaking change.

To minimize the impact, loading and initializing the tracer has been split into two different functions, the latter one being exported to the user. Thus the user is able to initialize the tracer exactly the same way this library would do it.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
