### PR TITLE
aj/fix lazy imports

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,2 +1,2 @@
 export { load, loadSync } from "./user-function";
-export { subscribeToDC, getTraceTree, RequireNode } from "./require-tracer"
+export { subscribeToDC, getTraceTree, clearTraceTree, RequireNode } from "./require-tracer"

--- a/src/runtime/require-tracer.ts
+++ b/src/runtime/require-tracer.ts
@@ -22,7 +22,7 @@ export class RequireNode {
 
 const moduleLoadStartChannel = dc.channel('dd-trace:moduleLoadStart')
 const moduleLoadEndChannel = dc.channel('dd-trace:moduleLoadEnd')
-const rootNodes: RequireNode[] = []
+let rootNodes: RequireNode[] = []
 
 const requireStack: RequireNode[] = []
 const pushNode = (data: any) => {
@@ -55,4 +55,8 @@ export const subscribeToDC = () => {
 
 export const getTraceTree = (): RequireNode[] => {
   return rootNodes
+}
+
+export const clearTraceTree = () => {
+  rootNodes = []
 }

--- a/src/trace/cold-start-tracer.spec.ts
+++ b/src/trace/cold-start-tracer.spec.ts
@@ -72,6 +72,7 @@ describe("ColdStartTracer", () => {
       currentSpanStartTime: 500,
       minDuration: 1,
       ignoreLibs: "",
+      isColdStart: true
     };
     const coldStartTracer = new ColdStartTracer(coldStartConfig);
     coldStartTracer.trace(requireNodes);
@@ -162,6 +163,7 @@ describe("ColdStartTracer", () => {
       currentSpanStartTime: 500,
       minDuration: 1,
       ignoreLibs: "myChildModule,myCoreModule",
+      isColdStart: true
     };
     const coldStartTracer = new ColdStartTracer(coldStartConfig);
     coldStartTracer.trace(requireNodes);
@@ -187,6 +189,88 @@ describe("ColdStartTracer", () => {
     const span3 = mockStartSpan.mock.calls[2];
     expect(span3[0]).toEqual("aws.lambda.require_runtime");
     expect(span3[1].tags).toEqual({
+      filename: "/var/runtime/aws-sdk",
+      operation_name: "aws.lambda.require_runtime",
+      "resource.name": "aws-sdk",
+      resource_names: "aws-sdk",
+      service: "aws.lambda",
+    });
+  });
+  it("traces lazy imports", () => {
+    const requireNodes: RequireNode[] = [
+      {
+        id: "handler",
+        filename: "/var/task/handler.js",
+        startTime: 1,
+        endTime: 6,
+        children: [
+          {
+            id: "myChildModule",
+            filename: "/opt/nodejs/node_modules/my-child-module.js",
+            startTime: 2,
+            endTime: 3,
+          },
+          {
+            id: "myCoreModule",
+            filename: "http",
+            startTime: 4,
+            endTime: 5,
+          },
+          {
+            id: "aws-sdk",
+            filename: "/var/runtime/aws-sdk",
+            startTime: 4,
+            endTime: 5,
+          },
+        ],
+      } as any as RequireNode,
+    ];
+    const coldStartConfig: ColdStartTracerConfig = {
+      tracerWrapper: new TracerWrapper(),
+      parentSpan: {
+        span: {},
+        name: "my-parent-span",
+      } as any as SpanWrapper,
+      lambdaFunctionName: "my-function-name",
+      currentSpanStartTime: 500,
+      minDuration: 1,
+      ignoreLibs: "",
+      isColdStart: false 
+    };
+    const coldStartTracer = new ColdStartTracer(coldStartConfig);
+    coldStartTracer.trace(requireNodes);
+    expect(mockStartSpan).toHaveBeenCalledTimes(4);
+    expect(mockFinishSpan).toHaveBeenCalledTimes(4);
+    const span1 = mockStartSpan.mock.calls[0];
+    expect(span1[0]).toEqual("aws.lambda.require");
+    expect(span1[1].tags).toEqual({
+      operation_name: "aws.lambda.require",
+      "resource.name": "handler",
+      resource_names: "handler",
+      service: "aws.lambda",
+      filename: "/var/task/handler.js",
+    });
+    const span2 = mockStartSpan.mock.calls[1];
+    expect(span2[0]).toEqual("aws.lambda.require_layer");
+    expect(span2[1].tags).toEqual({
+      filename: "/opt/nodejs/node_modules/my-child-module.js",
+      operation_name: "aws.lambda.require_layer",
+      "resource.name": "myChildModule",
+      resource_names: "myChildModule",
+      service: "aws.lambda",
+    });
+    const span3 = mockStartSpan.mock.calls[2];
+    expect(span3[0]).toEqual("aws.lambda.require_core_module");
+    expect(span3[1].tags).toEqual({
+      filename: "http",
+      operation_name: "aws.lambda.require_core_module",
+      "resource.name": "myCoreModule",
+      resource_names: "myCoreModule",
+      service: "aws.lambda",
+    });
+    const span4 = mockStartSpan.mock.calls[3];
+    expect(span4[0]).toEqual("aws.lambda.require_runtime");
+    expect(span4[1].tags).toEqual({
       filename: "/var/runtime/aws-sdk",
       operation_name: "aws.lambda.require_runtime",
       "resource.name": "aws-sdk",

--- a/src/trace/cold-start-tracer.spec.ts
+++ b/src/trace/cold-start-tracer.spec.ts
@@ -72,7 +72,7 @@ describe("ColdStartTracer", () => {
       currentSpanStartTime: 500,
       minDuration: 1,
       ignoreLibs: "",
-      isColdStart: true
+      isColdStart: true,
     };
     const coldStartTracer = new ColdStartTracer(coldStartConfig);
     coldStartTracer.trace(requireNodes);
@@ -163,7 +163,7 @@ describe("ColdStartTracer", () => {
       currentSpanStartTime: 500,
       minDuration: 1,
       ignoreLibs: "myChildModule,myCoreModule",
-      isColdStart: true
+      isColdStart: true,
     };
     const coldStartTracer = new ColdStartTracer(coldStartConfig);
     coldStartTracer.trace(requireNodes);
@@ -235,7 +235,7 @@ describe("ColdStartTracer", () => {
       currentSpanStartTime: 500,
       minDuration: 1,
       ignoreLibs: "",
-      isColdStart: false 
+      isColdStart: false,
     };
     const coldStartTracer = new ColdStartTracer(coldStartConfig);
     coldStartTracer.trace(requireNodes);

--- a/src/trace/cold-start-tracer.ts
+++ b/src/trace/cold-start-tracer.ts
@@ -37,9 +37,9 @@ export class ColdStartTracer {
     let targetParentSpan: SpanWrapper | undefined;
     if (this.isColdStart) {
       const coldStartSpan = this.createColdStartSpan(coldStartSpanStartTime, coldStartSpanEndTime, this.parentSpan);
-      targetParentSpan = coldStartSpan
+      targetParentSpan = coldStartSpan;
     } else {
-      targetParentSpan = this.parentSpan
+      targetParentSpan = this.parentSpan;
     }
     for (const coldStartNode of rootNodes) {
       this.traceTree(coldStartNode, targetParentSpan);

--- a/src/trace/cold-start-tracer.ts
+++ b/src/trace/cold-start-tracer.ts
@@ -9,6 +9,7 @@ export interface ColdStartTracerConfig {
   currentSpanStartTime: number;
   minDuration: number;
   ignoreLibs: string;
+  isColdStart: boolean;
 }
 
 export class ColdStartTracer {
@@ -18,6 +19,7 @@ export class ColdStartTracer {
   private currentSpanStartTime: number;
   private minDuration: number;
   private ignoreLibs: string[];
+  private isColdStart: boolean;
 
   constructor(coldStartTracerConfig: ColdStartTracerConfig) {
     this.tracerWrapper = coldStartTracerConfig.tracerWrapper;
@@ -26,14 +28,21 @@ export class ColdStartTracer {
     this.currentSpanStartTime = coldStartTracerConfig.currentSpanStartTime;
     this.minDuration = coldStartTracerConfig.minDuration;
     this.ignoreLibs = coldStartTracerConfig.ignoreLibs.split(",");
+    this.isColdStart = coldStartTracerConfig.isColdStart;
   }
 
   trace(rootNodes: RequireNode[]) {
     const coldStartSpanStartTime = rootNodes[0]?.startTime;
     const coldStartSpanEndTime = Math.min(rootNodes[rootNodes.length - 1]?.endTime, this.currentSpanStartTime);
-    const coldStartSpan = this.createColdStartSpan(coldStartSpanStartTime, coldStartSpanEndTime, this.parentSpan);
+    let targetParentSpan: SpanWrapper | undefined;
+    if (this.isColdStart) {
+      const coldStartSpan = this.createColdStartSpan(coldStartSpanStartTime, coldStartSpanEndTime, this.parentSpan);
+      targetParentSpan = coldStartSpan
+    } else {
+      targetParentSpan = this.parentSpan
+    }
     for (const coldStartNode of rootNodes) {
-      this.traceTree(coldStartNode, coldStartSpan);
+      this.traceTree(coldStartNode, targetParentSpan);
     }
   }
 

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -160,16 +160,16 @@ export class TraceListener {
     if (coldStartNodes.length > 0) {
       const coldStartConfig: ColdStartTracerConfig = {
         tracerWrapper: this.tracerWrapper,
-        parentSpan: didFunctionColdStart()? this.inferredSpan || this.wrappedCurrentSpan : this.wrappedCurrentSpan,
+        parentSpan: didFunctionColdStart() ? this.inferredSpan || this.wrappedCurrentSpan : this.wrappedCurrentSpan,
         lambdaFunctionName: this.context?.functionName,
         currentSpanStartTime: this.wrappedCurrentSpan?.startTime(),
         minDuration: this.config.minColdStartTraceDuration,
         ignoreLibs: this.config.coldStartTraceSkipLib,
-        isColdStart: didFunctionColdStart()
+        isColdStart: didFunctionColdStart(),
       };
       const coldStartTracer = new ColdStartTracer(coldStartConfig);
       coldStartTracer.trace(coldStartNodes);
-      clearTraceTree()
+      clearTraceTree();
     }
     if (this.triggerTags) {
       const statusCode = extractHTTPStatusCodeTag(this.triggerTags, result, isResponseStreamFunction);

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -19,7 +19,7 @@ import { patchConsole } from "./patch-console";
 import { SpanContext, TraceOptions, TracerWrapper } from "./tracer-wrapper";
 import { SpanInferrer } from "./span-inferrer";
 import { SpanWrapper } from "./span-wrapper";
-import { getTraceTree } from "../runtime/index";
+import { getTraceTree, clearTraceTree } from "../runtime/index";
 export type TraceExtractor = (event: any, context: Context) => Promise<TraceContext> | TraceContext;
 
 export interface TraceConfig {
@@ -157,7 +157,7 @@ export class TraceListener {
       tagObject(this.tracerWrapper.currentSpan, "function.response", result);
     }
     const coldStartNodes = getTraceTree();
-    if (coldStartNodes.length > 0 && didFunctionColdStart()) {
+    if (coldStartNodes.length > 0) {
       const coldStartConfig: ColdStartTracerConfig = {
         tracerWrapper: this.tracerWrapper,
         parentSpan: this.inferredSpan || this.wrappedCurrentSpan,
@@ -168,6 +168,7 @@ export class TraceListener {
       };
       const coldStartTracer = new ColdStartTracer(coldStartConfig);
       coldStartTracer.trace(coldStartNodes);
+      clearTraceTree()
     }
     if (this.triggerTags) {
       const statusCode = extractHTTPStatusCodeTag(this.triggerTags, result, isResponseStreamFunction);

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -160,11 +160,12 @@ export class TraceListener {
     if (coldStartNodes.length > 0) {
       const coldStartConfig: ColdStartTracerConfig = {
         tracerWrapper: this.tracerWrapper,
-        parentSpan: this.inferredSpan || this.wrappedCurrentSpan,
+        parentSpan: didFunctionColdStart()? this.inferredSpan || this.wrappedCurrentSpan : this.wrappedCurrentSpan,
         lambdaFunctionName: this.context?.functionName,
         currentSpanStartTime: this.wrappedCurrentSpan?.startTime(),
         minDuration: this.config.minColdStartTraceDuration,
         ignoreLibs: this.config.coldStartTraceSkipLib,
+        isColdStart: didFunctionColdStart()
       };
       const coldStartTracer = new ColdStartTracer(coldStartConfig);
       coldStartTracer.trace(coldStartNodes);


### PR DESCRIPTION
- fix: fix lazily loaded imports
- feat: Fix lazy loaded imports

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Needs tests.

This fixes an issue where lazy imports weren't traced.
This now parents them to the lambda span, like so:
<img width="1733" alt="image" src="https://github.com/DataDog/datadog-lambda-js/assets/1598537/a6804cb8-cd17-410c-9994-ee6362697807">


Normal cold start traces are unaffected:
<img width="1023" alt="image" src="https://github.com/DataDog/datadog-lambda-js/assets/1598537/1c792eaa-3b56-4dd9-a128-2eb4c375605a">


### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
