### PR TITLE
feat: Explicitly try/catch require to appease esbuild

### DIFF
--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -44,11 +44,11 @@ export class KMSService {
 
   // Node 18 or AWS SDK V3
   public async decryptV3(buffer: Buffer): Promise<string> {
-    let KMSClient, DecryptCommand
+    let KMSClient, DecryptCommand;
     try {
       ({ KMSClient, DecryptCommand } = require("@aws-sdk/client-kms"));
-    } catch(e) {
-      throw Error("Can't load AWS SDK v2 or v3 to decrypt KMS key, custom metrics may not be sent")
+    } catch (e) {
+      throw Error("Can't load AWS SDK v2 or v3 to decrypt KMS key, custom metrics may not be sent");
     }
     const kmsClient = new KMSClient();
     let result;

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -44,8 +44,11 @@ export class KMSService {
 
   // Node 18 or AWS SDK V3
   public async decryptV3(buffer: Buffer): Promise<string> {
+    // tslint:disable-next-line: variable-name
+    // tslint:disable one-variable-per-declaration
     let KMSClient, DecryptCommand;
     try {
+
       ({ KMSClient, DecryptCommand } = require("@aws-sdk/client-kms"));
     } catch (e) {
       throw Error("Can't load AWS SDK v2 or v3 to decrypt KMS key, custom metrics may not be sent");

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -12,6 +12,9 @@ export class KMSService {
     const buffer = Buffer.from(ciphertext, "base64");
     let kms
 
+    // Explicitly try/catch this require to appease esbuild and ts compiler
+    // otherwise users would need to mark this as `external`
+    // see https://github.com/DataDog/datadog-lambda-js/pull/409
     try {
       kms = require("aws-sdk/clients/kms");
     } catch (err) {
@@ -50,6 +53,9 @@ export class KMSService {
   public async decryptV3(buffer: Buffer): Promise<string> {
     // tslint:disable-next-line: variable-name one-variable-per-declaration
     let KMSClient, DecryptCommand;
+    // Explicitly try/catch this require to appease esbuild and ts compiler
+    // otherwise users would need to mark this as `external`
+    // see https://github.com/DataDog/datadog-lambda-js/pull/409
     try {
       ({ KMSClient, DecryptCommand } = require("@aws-sdk/client-kms"));
     } catch (e) {

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -44,7 +44,12 @@ export class KMSService {
 
   // Node 18 or AWS SDK V3
   public async decryptV3(buffer: Buffer): Promise<string> {
-    const { KMSClient, DecryptCommand } = require("@aws-sdk/client-kms");
+    let KMSClient, DecryptCommand
+    try {
+      ({ KMSClient, DecryptCommand } = require("@aws-sdk/client-kms"));
+    } catch(e) {
+      throw Error("Can't load AWS SDK v2 or v3 to decrypt KMS key, custom metrics may not be sent")
+    }
     const kmsClient = new KMSClient();
     let result;
     try {

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -44,11 +44,9 @@ export class KMSService {
 
   // Node 18 or AWS SDK V3
   public async decryptV3(buffer: Buffer): Promise<string> {
-    // tslint:disable-next-line: variable-name
-    // tslint:disable one-variable-per-declaration
+    // tslint:disable-next-line: variable-name one-variable-per-declaration
     let KMSClient, DecryptCommand;
     try {
-
       ({ KMSClient, DecryptCommand } = require("@aws-sdk/client-kms"));
     } catch (e) {
       throw Error("Can't load AWS SDK v2 or v3 to decrypt KMS key, custom metrics may not be sent");

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -10,7 +10,7 @@ export class KMSService {
 
   public async decrypt(ciphertext: string): Promise<string> {
     const buffer = Buffer.from(ciphertext, "base64");
-    let kms
+    let kms;
 
     // Explicitly try/catch this require to appease esbuild and ts compiler
     // otherwise users would need to mark this as `external`

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -10,9 +10,17 @@ export class KMSService {
 
   public async decrypt(ciphertext: string): Promise<string> {
     const buffer = Buffer.from(ciphertext, "base64");
+    let kms
 
     try {
-      const kms = require("aws-sdk/clients/kms");
+      kms = require("aws-sdk/clients/kms");
+    } catch (err) {
+      if ((err as any).code === "MODULE_NOT_FOUND") {
+        // Node 18
+        return this.decryptV3(buffer);
+      }
+    }
+    try {
       const kmsClient = new kms();
 
       // When the API key is encrypted using the AWS console, the function name is added as an encryption context.
@@ -34,10 +42,6 @@ export class KMSService {
       }
       return result.Plaintext.toString("ascii");
     } catch (err) {
-      if ((err as any).code === "MODULE_NOT_FOUND") {
-        // Node 18
-        return this.decryptV3(buffer);
-      }
       throw Error("Couldn't decrypt ciphertext");
     }
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Hopefully fixes #408

### Motivation
I'm still testing this, want to get it on a PR for integration tests. But apparently our callpath try/catch isn't enough to convince esbuild that this library is provided externally.

### Testing Guidelines

I build this project and then tested it locally with `npx esbuild dist/index.js --bundle --minify --platform=node` and did not receive any errors.

For developers finding this in the future, you can test this is error-free by:
1. Pulling this project
2. Running `yarn install`
3. _removing_ `node_modules/@aws-sdk` and `node_modules/aws-sdk` entirely! <- This step is KEY.
4. Running `yarn build`
5. Running `npx esbuild dist/index.js --bundle --minify --platform=node` and confirming you do not receive any build errors.

An esbuild error looks like this:
```
npx esbuild dist/index.js --bundle --minify --platform=node
✘ [ERROR] Could not resolve "aws-sdk/clients/kms"

    dist/metrics/kms-service.js:57:38:
      57 │                         kms = require("aws-sdk/clients/kms");
         ╵                                       ~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "aws-sdk/clients/kms" as external to exclude it from the bundle, which will
  remove this error. You can also surround this "require" call with a try/catch block to handle this
  failure at run-time instead of bundle-time.

1 error
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
