### PR TITLE
feat: Bump ddtrace to 3.38.1

### DIFF
--- a/integration_tests/snapshots/logs/process-input-traced_node14.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node14.log
@@ -48,6 +48,7 @@ START
           "http.method": "GET",
           "stage": "test",
           "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -83,6 +84,7 @@ START
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
           "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -216,6 +218,7 @@ START
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -248,6 +251,7 @@ START
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_type": "SNS",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -336,6 +340,7 @@ START
           "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -369,6 +374,7 @@ START
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "event_type": "SQS",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node14",
           "language": "javascript"
         },
         "metrics": {

--- a/integration_tests/snapshots/logs/process-input-traced_node16.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node16.log
@@ -49,6 +49,7 @@ START
           "http.method": "GET",
           "stage": "test",
           "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -85,6 +86,7 @@ START
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
           "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -222,6 +224,7 @@ START
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -255,6 +258,7 @@ START
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_type": "SNS",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -345,6 +349,7 @@ START
           "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -379,6 +384,7 @@ START
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "event_type": "SQS",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node16",
           "language": "javascript"
         },
         "metrics": {

--- a/integration_tests/snapshots/logs/process-input-traced_node18.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node18.log
@@ -49,6 +49,7 @@ START
           "http.method": "GET",
           "stage": "test",
           "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -85,6 +86,7 @@ START
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
           "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -222,6 +224,7 @@ START
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -255,6 +258,7 @@ START
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_type": "SNS",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -345,6 +349,7 @@ START
           "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -379,6 +384,7 @@ START
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "event_type": "SQS",
+          "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {

--- a/integration_tests/snapshots/logs/status-code-500s_node14.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node14.log
@@ -54,6 +54,7 @@ START
           "http.method": "GET",
           "stage": "test",
           "http.status_code": "500",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -87,6 +88,7 @@ START
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
           "http.status_code": "500",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -167,6 +169,7 @@ START
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -198,6 +201,7 @@ START
           "datadog_lambda":"XXXX",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -254,6 +258,7 @@ START
           "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node14",
           "language": "javascript"
         },
         "metrics": {
@@ -286,6 +291,7 @@ START
           "datadog_lambda":"XXXX",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node14",
           "language": "javascript"
         },
         "metrics": {

--- a/integration_tests/snapshots/logs/status-code-500s_node16.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node16.log
@@ -55,6 +55,7 @@ START
           "http.method": "GET",
           "stage": "test",
           "http.status_code": "500",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -89,6 +90,7 @@ START
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
           "http.status_code": "500",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -171,6 +173,7 @@ START
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -203,6 +206,7 @@ START
           "datadog_lambda":"XXXX",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -260,6 +264,7 @@ START
           "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node16",
           "language": "javascript"
         },
         "metrics": {
@@ -293,6 +298,7 @@ START
           "datadog_lambda":"XXXX",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node16",
           "language": "javascript"
         },
         "metrics": {

--- a/integration_tests/snapshots/logs/status-code-500s_node18.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node18.log
@@ -55,6 +55,7 @@ START
           "http.method": "GET",
           "stage": "test",
           "http.status_code": "500",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -89,6 +90,7 @@ START
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
           "http.status_code": "500",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -171,6 +173,7 @@ START
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -203,6 +206,7 @@ START
           "datadog_lambda":"XXXX",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -260,6 +264,7 @@ START
           "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -293,6 +298,7 @@ START
           "datadog_lambda":"XXXX",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^15.6.1",
     "@types/promise-retry": "^1.1.3",
     "@types/shimmer": "^1.0.1",
-    "dd-trace": "^3.32.1",
+    "dd-trace": "^3.38.1",
     "jest": "^27.0.1",
     "mock-fs": "4.14.0",
     "nock": "13.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,24 +700,25 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@datadog/native-appsec@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-3.2.0.tgz#ddeca06cbaba9c6905903d09d18013f81eedc8c3"
-  integrity sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==
+"@datadog/native-appsec@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-4.0.0.tgz#ee08138b987dec557eac3650a43a972dac85b6a6"
+  integrity sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz#dc4a23796870f2d840053ae879c61547eda6bb89"
-  integrity sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==
+"@datadog/native-iast-rewriter@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.1.3.tgz#1964cd856655b9c4d0e144048af59a2e90910901"
+  integrity sha512-4oxMFz5ZEpOK3pRc9KjquMgkRP6D+oPQVIzOk4dgG8fl2iepHtCa3gna/fQBfdWIiX5a2j65O3R1zNp2ckk8JA==
   dependencies:
+    lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz#1a55eca6692079ac6167696682acb972aa0b0181"
-  integrity sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==
+"@datadog/native-iast-taint-tracking@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.1.tgz#fcf2f376797dbfc368d6cb3636b922372d2be50e"
+  integrity sha512-V1X0UbEROcEkqP4IIovqK9uu8jPXq80m8xOW1Vb6xJ9otO3eBphvDFDSa/OJ4pEYhajjjmGlraLlV6rXjaSGlQ==
   dependencies:
     node-gyp-build "^3.9.0"
 
@@ -729,10 +730,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-3.1.0.tgz#d58aac33985dbb71f77d85a41023a35f1ad55290"
-  integrity sha512-Bg8O8yrHeL2KKHXhLoAAT33ZfzLnZ6rWfOjy8PkcNhUJy3UwNVLbUoApf+99EyLjqpzpk/kZXrIAMBzMMB8ilg==
+"@datadog/pprof@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-4.0.0.tgz#2ef48977292496f7b300ff97605f0853f7340586"
+  integrity sha512-1rQV6arh5fp7BWshjHgKmhNzXELAIod1Y4ydkI7XRcRim35uBoxQgPy1VgMCuLjfzco7112Vt8bkfQxo9bIdoA==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"
@@ -1979,16 +1980,16 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dd-trace@^3.32.1:
-  version "3.33.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-3.33.0.tgz#d541cdae130cacbe6730d0100d91043e60aa84c4"
-  integrity sha512-ed7XMiWVAfF51V6dGwPA6TlhTIPUMxE62arc4U2SzS6n0B41tZHpc0n53NnfdaBnDp19epIgbtHdCm3sT00SJg==
+dd-trace@^3.38.1:
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-3.38.1.tgz#a10ff12973870fab74b476909538ef280af5a3d0"
+  integrity sha512-VsWsb5rY+AqS/HPZf+Lq7bH7mm9iQrLkkCUqF6vU4BGjPn2Pv77ntW0XiLIUhJl64feXd+x61zRZLbnHZLFy2w==
   dependencies:
-    "@datadog/native-appsec" "^3.2.0"
-    "@datadog/native-iast-rewriter" "2.0.1"
-    "@datadog/native-iast-taint-tracking" "1.5.0"
+    "@datadog/native-appsec" "^4.0.0"
+    "@datadog/native-iast-rewriter" "2.1.3"
+    "@datadog/native-iast-taint-tracking" "1.6.1"
     "@datadog/native-metrics" "^2.0.0"
-    "@datadog/pprof" "3.1.0"
+    "@datadog/pprof" "4.0.0"
     "@datadog/sketches-js" "^2.1.0"
     "@opentelemetry/api" "^1.0.0"
     "@opentelemetry/core" "^1.14.0"
@@ -1999,6 +2000,7 @@ dd-trace@^3.32.1:
     int64-buffer "^0.1.9"
     ipaddr.js "^2.1.0"
     istanbul-lib-coverage "3.2.0"
+    jest-docblock "^29.7.0"
     koalas "^1.0.2"
     limiter "^1.1.4"
     lodash.kebabcase "^4.1.1"
@@ -2687,6 +2689,13 @@ jest-docblock@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.5.1.tgz#14092f364a42c6108d42c33c8cf30e058e25f6c0"
   integrity sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-docblock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
+  integrity sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==
   dependencies:
     detect-newline "^3.0.0"
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Bumps to the latest minor of ddtracejs, staying on the 3.x line as it supports all current versions of node in AWS.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
