### PR TITLE
feat: use multiple processes to publish layers

### DIFF
--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -10,7 +10,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 ./scripts/build_layers.sh
-VERSION=$VERSION REGIONS=us-east-1 ./scripts/publish_layers.sh
+VERSION=$VERSION ./scripts/publish_layers.sh
 
 # Automatically create PR against github.com/DataDog/documentation
 # If you'd like to test, please uncomment the below line

--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -10,7 +10,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 ./scripts/build_layers.sh
-VERSION=$VERSION REGIONS=sa-east-1 ./scripts/publish_layers.sh
+VERSION=$VERSION REGIONS=us-east-1 ./scripts/publish_layers.sh
 
 # Automatically create PR against github.com/DataDog/documentation
 # If you'd like to test, please uncomment the below line


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
1. Revives some old code which spins off child processes (with `&`) and tracks the pids up to a batch size to make backfilling layers faster
2. *removes the backfill confirmation logic* and instead warns:
<img width="1046" alt="image" src="https://github.com/DataDog/datadog-lambda-js/assets/1598537/46ee9e86-9072-4ae0-a818-7b9f32c12630">
3. Removes the region arg, we already ask/confirm so if they don't pass it, we don't need to choose it:
<img width="766" alt="image" src="https://github.com/DataDog/datadog-lambda-js/assets/1598537/01785d9f-8c98-4d13-af4e-536ef542e7e2">

### Motivation

I've never said "no" to a backfill, and I can't think of a condition where we would say no unless we inadvertently used a large number for the target version (eg 999 instead of 99). This script could simply be killed and started again with the lower number, as lambda will only let us increment versions upwards anyways.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
