### PR TITLE
feat: bump ddtrace to 3.41.0

### DIFF
--- a/integration_tests/snapshots/logs/process-input-traced_node14.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node14.log
@@ -35,6 +35,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "runtime-id":"XXXX",
@@ -204,6 +205,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "runtime-id":"XXXX",
@@ -328,6 +330,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "runtime-id":"XXXX",

--- a/integration_tests/snapshots/logs/process-input-traced_node16.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node16.log
@@ -35,6 +35,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "version": "1.0.0",
@@ -209,6 +210,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "version": "1.0.0",
@@ -336,6 +338,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "version": "1.0.0",

--- a/integration_tests/snapshots/logs/process-input-traced_node18.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node18.log
@@ -35,6 +35,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "version": "1.0.0",
@@ -209,6 +210,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "version": "1.0.0",
@@ -336,6 +338,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "version": "1.0.0",

--- a/integration_tests/snapshots/logs/process-input-traced_node20.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node20.log
@@ -35,6 +35,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "version": "1.0.0",
@@ -209,6 +210,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "version": "1.0.0",
@@ -336,6 +338,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "version": "1.0.0",

--- a/integration_tests/snapshots/logs/status-code-500s_node14.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node14.log
@@ -41,6 +41,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "runtime-id":"XXXX",
@@ -155,6 +156,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "runtime-id":"XXXX",
@@ -246,6 +248,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "runtime-id":"XXXX",

--- a/integration_tests/snapshots/logs/status-code-500s_node16.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node16.log
@@ -41,6 +41,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "version": "1.0.0",
@@ -158,6 +159,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "version": "1.0.0",
@@ -251,6 +253,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "version": "1.0.0",

--- a/integration_tests/snapshots/logs/status-code-500s_node18.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node18.log
@@ -41,6 +41,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "version": "1.0.0",
@@ -158,6 +159,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "version": "1.0.0",
@@ -251,6 +253,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "version": "1.0.0",

--- a/integration_tests/snapshots/logs/status-code-500s_node20.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node20.log
@@ -41,6 +41,7 @@ START
         "resource": "GET /{proxy+}",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
           "version": "1.0.0",
@@ -158,6 +159,7 @@ START
         "resource": "sns-lambda",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
           "version": "1.0.0",
@@ -251,6 +253,7 @@ START
         "resource": "my-queue",
         "error": 0,
         "meta": {
+          "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.1",
+    "dc-polyfill": "^0.1.3",
     "hot-shots": "8.5.0",
     "promise-retry": "^2.0.1",
     "serialize-error": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^15.6.1",
     "@types/promise-retry": "^1.1.3",
     "@types/shimmer": "^1.0.1",
-    "dd-trace": "^3.38.1",
+    "dd-trace": "^3.41.0",
     "jest": "^27.0.1",
     "mock-fs": "4.14.0",
     "nock": "13.0.11",

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -221,7 +221,10 @@ for handler_name in "${LAMBDA_HANDLERS[@]}"; do
                 # Normalize Axios version
                 perl -p -e "s/User-Agent:axios\/\d+\.\d+\.\d+/User-Agent:axios\/X\.X\.X/g" |
                 # Remove init start line
-                perl -p -e "s/INIT_START.*//g"
+                perl -p -e "s/INIT_START.*//g" |
+                sed -E "s/(tracestate\:)([A-Za-z0-9\-\=\:\;].+)/\1XXX/g" |
+                sed -E "s/(\"_dd.p.tid\"\: \")[a-z0-9\.\-]+/\1XXXX/g" |
+                sed -E "s/(_dd.p.tid=)[a-z0-9\.\-]+/\1XXXX/g"
         )
 
         if [ ! -f $function_snapshot_path ]; then

--- a/src/runtime/require-tracer.spec.ts
+++ b/src/runtime/require-tracer.spec.ts
@@ -1,5 +1,5 @@
 import { subscribeToDC, getTraceTree, RequireNode } from "./require-tracer";
-const dc = require('diagnostics_channel')
+const dc = require('dc-polyfill')
 
 describe('require-tracer', () => {
   it('generates a trace tree', () => {

--- a/src/runtime/require-tracer.ts
+++ b/src/runtime/require-tracer.ts
@@ -1,4 +1,4 @@
-const dc = require('diagnostics_channel')
+const dc = require('dc-polyfill')
 
 export class RequireNode {
   public id: string

--- a/src/runtime/require-tracer.ts
+++ b/src/runtime/require-tracer.ts
@@ -1,3 +1,4 @@
+// TODO NEXT MAJOR (AJ): Remove this when we drop node14
 const dc = require('dc-polyfill')
 
 export class RequireNode {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,7 +2040,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dc-polyfill@^0.1.2:
+dc-polyfill@^0.1.2, dc-polyfill@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.3.tgz#fe9eefc86813439dd46d6f9ad9582ec079c39720"
   integrity sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,25 +760,25 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@datadog/native-appsec@^4.0.0":
+"@datadog/native-appsec@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-4.0.0.tgz#ee08138b987dec557eac3650a43a972dac85b6a6"
   integrity sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.1.3.tgz#1964cd856655b9c4d0e144048af59a2e90910901"
-  integrity sha512-4oxMFz5ZEpOK3pRc9KjquMgkRP6D+oPQVIzOk4dgG8fl2iepHtCa3gna/fQBfdWIiX5a2j65O3R1zNp2ckk8JA==
+"@datadog/native-iast-rewriter@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.1.tgz#3c74c5a8caa0b876e091e9c5a95256add0d73e1c"
+  integrity sha512-DyZlE8gNa5AoOFNKGRJU4RYF/Y/tJzv4bIAMuVBbEnMA0xhiIYqpYQG8T3OKkALl3VSEeBMjYwuOR2fCrJ6gzA==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.1.tgz#fcf2f376797dbfc368d6cb3636b922372d2be50e"
-  integrity sha512-V1X0UbEROcEkqP4IIovqK9uu8jPXq80m8xOW1Vb6xJ9otO3eBphvDFDSa/OJ4pEYhajjjmGlraLlV6rXjaSGlQ==
+"@datadog/native-iast-taint-tracking@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz#16c21ad7c36a53420c0d3c5a3720731809cc7e98"
+  integrity sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==
   dependencies:
     node-gyp-build "^3.9.0"
 
@@ -790,10 +790,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-4.0.0.tgz#2ef48977292496f7b300ff97605f0853f7340586"
-  integrity sha512-1rQV6arh5fp7BWshjHgKmhNzXELAIod1Y4ydkI7XRcRim35uBoxQgPy1VgMCuLjfzco7112Vt8bkfQxo9bIdoA==
+"@datadog/pprof@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-4.0.1.tgz#f8629ecb62646d90ed49b6252dd0583d8d5001d3"
+  integrity sha512-TavqyiyQZOaUM9eQB07r8+K/T1CqKyOdsUGxpN79+BF+eOQBpTj/Cte6KdlhcUSKL3h5hSjC+vlgA7uW2qtVhA==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"
@@ -2040,21 +2040,26 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dd-trace@^3.38.1:
-  version "3.38.1"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-3.38.1.tgz#a10ff12973870fab74b476909538ef280af5a3d0"
-  integrity sha512-VsWsb5rY+AqS/HPZf+Lq7bH7mm9iQrLkkCUqF6vU4BGjPn2Pv77ntW0XiLIUhJl64feXd+x61zRZLbnHZLFy2w==
+dc-polyfill@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.3.tgz#fe9eefc86813439dd46d6f9ad9582ec079c39720"
+  integrity sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==
+
+dd-trace@^3.41.0:
+  version "3.41.0"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-3.41.0.tgz#ea9f9321cbd58eb958448f84b4defdeef6fb8b93"
+  integrity sha512-6o+Pmc3HRyCcvePezHWJsA4LfYH1catCVfveGt7BnAA2POAQlRjMUYWo1KqVSV+s04BjSbBlUycR2uyFVupoew==
   dependencies:
-    "@datadog/native-appsec" "^4.0.0"
-    "@datadog/native-iast-rewriter" "2.1.3"
-    "@datadog/native-iast-taint-tracking" "1.6.1"
+    "@datadog/native-appsec" "4.0.0"
+    "@datadog/native-iast-rewriter" "2.2.1"
+    "@datadog/native-iast-taint-tracking" "1.6.4"
     "@datadog/native-metrics" "^2.0.0"
-    "@datadog/pprof" "4.0.0"
+    "@datadog/pprof" "4.0.1"
     "@datadog/sketches-js" "^2.1.0"
     "@opentelemetry/api" "^1.0.0"
     "@opentelemetry/core" "^1.14.0"
     crypto-randomuuid "^1.0.0"
-    diagnostics_channel "^1.1.0"
+    dc-polyfill "^0.1.2"
     ignore "^5.2.4"
     import-in-the-middle "^1.4.2"
     int64-buffer "^0.1.9"
@@ -2074,6 +2079,7 @@ dd-trace@^3.38.1:
     node-abort-controller "^3.1.1"
     opentracing ">=0.12.1"
     path-to-regexp "^0.1.2"
+    pprof-format "^2.0.7"
     protobufjs "^7.2.4"
     retry "^0.13.1"
     semver "^7.5.4"
@@ -2114,11 +2120,6 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-diagnostics_channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz#bd66c49124ce3bac697dff57466464487f57cea5"
-  integrity sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==
 
 diff-sequences@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Bumps `dd-trace` to `v3.41.0`.

### Motivation

Support W3C 128bit trace IDs.

### Testing Guidelines

Updated integration tests.

### Additional Notes

This PR also adds the `dc-polyfill` dependency required to use with `dd-trace`.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
