### PR TITLE
[SLES-1463] [bugfix] ddtrace spancontext traceid need to be object

### DIFF
--- a/src/trace/span-context-wrapper.spec.ts
+++ b/src/trace/span-context-wrapper.spec.ts
@@ -1,0 +1,26 @@
+import { SpanContextWrapper } from "./span-context-wrapper";
+import { TraceSource } from "./trace-context-service";
+
+describe("SpanContextWrapper", () => {
+  beforeEach(() => {});
+
+  it("fromTraceContext", () => {
+    const traceContext = {
+      traceId: "8768810343773813232",
+      parentId: "6004d9aeb61ddcac",
+      sampleMode: 1,
+      source: TraceSource.Event,
+    };
+    const spanContext = SpanContextWrapper.fromTraceContext(traceContext);
+
+    expect(spanContext?.toTraceId()).toBe("8768810343773813232");
+    expect(spanContext?.toSpanId()).toBe("6004d9aeb61ddcac");
+    expect(spanContext?.sampleMode()).toBe("1");
+    expect(spanContext?.source).toBe("event");
+    // The inner type dd-trace/packages/dd-trace/src/opentracing/span_context
+    // must have traceId and spanId as objects instead of strings because of the toArray() call
+    // https://github.com/DataDog/dd-trace-js/blob/9c71b3060081a77639bab4c6b2a26c952f4a114f/packages/dd-trace/src/encode/0.4.js#L168
+    expect(spanContext?.spanContext._traceId).toBeInstanceOf(Object);
+    expect(spanContext?.spanContext._spanId).toBeInstanceOf(Object);
+  });
+});

--- a/src/trace/span-context-wrapper.ts
+++ b/src/trace/span-context-wrapper.ts
@@ -49,9 +49,11 @@ export class SpanContextWrapper implements SpanContext {
       const _DatadogSpanContext = require("dd-trace/packages/dd-trace/src/opentracing/span_context");
 
       return new SpanContextWrapper(
+        // The inner type _DatadogSpanContext must have traceId and spanId as objects instead of strings because of the toArray() call
+        // https://github.com/DataDog/dd-trace-js/blob/9c71b3060081a77639bab4c6b2a26c952f4a114f/packages/dd-trace/src/encode/0.4.js#L168
         new _DatadogSpanContext({
-          traceId,
-          spanId,
+          traceId: new String(traceId),
+          spanId: new String(spanId),
           sampling: { priority: samplingPriority },
         }),
         source,

--- a/src/trace/span-context-wrapper.ts
+++ b/src/trace/span-context-wrapper.ts
@@ -52,7 +52,9 @@ export class SpanContextWrapper implements SpanContext {
         // The inner type _DatadogSpanContext must have traceId and spanId as objects instead of strings because of the toArray() call
         // https://github.com/DataDog/dd-trace-js/blob/9c71b3060081a77639bab4c6b2a26c952f4a114f/packages/dd-trace/src/encode/0.4.js#L168
         new _DatadogSpanContext({
+          // tslint:disable-next-line:no-construct
           traceId: new String(traceId),
+          // tslint:disable-next-line:no-construct
           spanId: new String(spanId),
           sampling: { priority: samplingPriority },
         }),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR ensures that the traceId and spanId are boxed as a String object when creating the dd-trace/span-context type (so that later it won't error out [when calling toArray()](https://github.com/DataDog/dd-trace-js/blob/9c71b3060081a77639bab4c6b2a26c952f4a114f/packages/dd-trace/src/encode/0.4.js#L168))

### Motivation
We have a customer issue linked here. 
The error stacktrace is 
```
2023-12-07T13:57:10.020Z	c241f8c3-8001-4a5d-a333-6ae15155d2a2	DEBUG	{
    "status": "debug",
    "message": "id.toArray is not a function",
    "name": "TypeError",
    "stack": "TypeError: id.toArray is not a function\n    at AgentEncoder._encodeId (/var/task/node_modules/dd-trace/packages/dd-trace/src/encode/0.4.js:168:13)\n    at AgentEncoder._encode (/var/task/node_modules/dd-trace/packages/dd-trace/src/encode/0.4.js:96:12)\n    at AgentEncoder.encode (/var/task/node_modules/dd-trace/packages/dd-trace/src/encode/0.4.js:45:10)\n    at Writer._encode (/var/task/node_modules/dd-trace/packages/dd-trace/src/exporters/common/writer.js:39:19)\n    at Writer.append (/var/task/node_modules/dd-trace/packages/dd-trace/src/exporters/common/writer.js:35:10)\n    at AgentExporter.export (/var/task/node_modules/dd-trace/packages/dd-trace/src/exporters/agent/index.js:45:18)\n    at SpanProcessor.process (/var/task/node_modules/dd-trace/packages/dd-trace/src/span_processor.js:53:30)\n    at DatadogSpan.finish (/var/task/node_modules/dd-trace/packages/dd-trace/src/opentracing/span.js:183:21)\n    at SpanWrapper.finish (/var/task/node_modules/datadog-lambda-js/dist/trace/span-wrapper.js:28:19)\n    at TraceListener.<anonymous> (/var/task/node_modules/datadog-lambda-js/dist/trace/listener.js:227:39)"
}
```
This issue can be replicated when trying to passing down x-ray trace context with `DD_MERGE_XRAY_TRACES: true`

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

- added one unittest to ensure the type
- tested with reproduced example in sandbox account
<img width="1552" alt="Screenshot 2023-12-07 at 10 45 46 AM" src="https://github.com/DataDog/datadog-lambda-js/assets/5253430/35bc7bb4-e5ea-427d-abbe-6c307ee70529">

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
