### PR TITLE
feat: Skip the flush() call unless the DD_LOCAL_TEST env var is set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -369,8 +369,10 @@ function getConfig(userConfig?: Partial<Config>): Config {
 
   if (userConfig === undefined || userConfig.localTesting === undefined) {
     const result = getEnvValue(localTestingEnvVar, "false").toLowerCase();
+    // TODO deprecate 1 for truthy, this shouldn't have been allowed
+    // but the extension allows it, so we must as well
     // @ts-ignore-next-line
-    config.localTesting = result === "true" || result === '1';
+    config.localTesting = result === "true" || result === "1";
   }
 
   return config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,10 @@ function getConfig(userConfig?: Partial<Config>): Config {
 
   if (userConfig === undefined || userConfig.localTesting === undefined) {
     const result = getEnvValue(localTestingEnvVar, "false").toLowerCase();
-    config.localTesting = result === "true";
+    // TODO deprecate 1 for truthy, this shouldn't have been allowed
+    // but the extension allows it, so we must as well
+    // @ts-ignore-next-line
+    config.localTesting = result === "true" || result === "1";
   }
 
   return config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export const decodeAuthorizerContextEnvVar = "DD_DECODE_AUTHORIZER_CONTEXT";
 export const coldStartTracingEnvVar = "DD_COLD_START_TRACING";
 export const minColdStartTraceDurationEnvVar = "DD_MIN_COLD_START_DURATION";
 export const coldStartTraceSkipLibEnvVar = "DD_COLD_START_TRACE_SKIP_LIB";
+export const localTestingEnvVar = "DD_LOCAL_TESTING";
 
 interface GlobalConfig {
   /**
@@ -86,6 +87,7 @@ export const defaultConfig: Config = {
   siteURL: "",
   minColdStartTraceDuration: 3,
   coldStartTraceSkipLib: "",
+  localTesting: false,
 } as const;
 
 let currentMetricsListener: MetricsListener | undefined;
@@ -363,6 +365,11 @@ function getConfig(userConfig?: Partial<Config>): Config {
 
   if (userConfig === undefined || userConfig.captureLambdaPayloadMaxDepth === undefined) {
     config.captureLambdaPayloadMaxDepth = Number(getEnvValue(captureLambdaPayloadMaxDepthEnvVar, "10"));
+  }
+
+  if (userConfig === undefined || userConfig.localTesting === undefined) {
+    const result = getEnvValue(localTestingEnvVar, "false").toLowerCase();
+    config.localTesting = result === "true";
   }
 
   return config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,10 +369,7 @@ function getConfig(userConfig?: Partial<Config>): Config {
 
   if (userConfig === undefined || userConfig.localTesting === undefined) {
     const result = getEnvValue(localTestingEnvVar, "false").toLowerCase();
-    // TODO deprecate 1 for truthy, this shouldn't have been allowed
-    // but the extension allows it, so we must as well
-    // @ts-ignore-next-line
-    config.localTesting = result === "true" || result === "1";
+    config.localTesting = result === "true";
   }
 
   return config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,8 @@ function getConfig(userConfig?: Partial<Config>): Config {
 
   if (userConfig === undefined || userConfig.localTesting === undefined) {
     const result = getEnvValue(localTestingEnvVar, "false").toLowerCase();
-    config.localTesting = result === "true";
+    // @ts-ignore-next-line
+    config.localTesting = result === "true" || result === '1';
   }
 
   return config;

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -37,6 +37,7 @@ describe("MetricsListener", () => {
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
+      localTesting: false,
       siteURL,
     });
 
@@ -56,6 +57,7 @@ describe("MetricsListener", () => {
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
+      localTesting: false,
       siteURL,
     });
 
@@ -73,6 +75,7 @@ describe("MetricsListener", () => {
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
+      localTesting: false,
       siteURL,
     });
 
@@ -91,6 +94,7 @@ describe("MetricsListener", () => {
       enhancedMetrics: false,
       logForwarding: true,
       shouldRetryMetrics: false,
+      localTesting: false,
       siteURL,
     });
     jest.useFakeTimers("legacy");
@@ -124,6 +128,7 @@ describe("MetricsListener", () => {
       enhancedMetrics: false,
       logForwarding: true,
       shouldRetryMetrics: false,
+      localTesting: true,
       siteURL,
     });
     jest.useFakeTimers("legacy");
@@ -146,6 +151,7 @@ describe("MetricsListener", () => {
       enhancedMetrics: false,
       logForwarding: true,
       shouldRetryMetrics: false,
+      localTesting: false,
       siteURL,
     });
     // jest.useFakeTimers();

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -46,6 +46,13 @@ export interface MetricsConfig {
    * @default false
    */
   enhancedMetrics: boolean;
+
+  /**
+   * Whether to call the extension's Flush endpoint in a local test
+   * Only needed locally, as the extension knows about the end of the invocation
+   * from the runtime
+   */
+  localTesting: boolean;
 }
 
 export class MetricsListener {
@@ -114,8 +121,8 @@ export class MetricsListener {
       }
     }
     try {
-      if (this.isAgentRunning) {
-        logDebug(`Flushing Extension`);
+      if (this.isAgentRunning && this.config.localTesting) {
+        logDebug(`Flushing Extension for local test`);
         await flushExtension();
       }
     } catch (error) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Removes the call to `/flush`, as the telemetry-api tells us this information now

Fixes #452 

### Motivation
We'd like to remove this entirely but it's required for people using the extension in a local testing mode. We don't intend to further support local testing in this library at this time.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
