### PR TITLE
feat: Fix FD leak in request

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -55,7 +55,7 @@ function sendRequest(url: URL, options: RequestOptions, buffer?: Buffer): Promis
 
       // https://nodejs.org/api/http.html#class-httpclientrequest
       // "Until the data is consumed, the 'end' event will not fire. Also, until the data is read it will consume memory that can eventually lead to a 'process out of memory' error"
-      response.resume()
+      response.resume();
 
       if (statusCode === undefined || statusCode < 200 || statusCode > 299) {
         return resolve({

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -40,12 +40,20 @@ export function get(url: URL, options?: Partial<RequestOptions>): Promise<Reques
   return sendRequest(url, requestOptions);
 }
 
+// This utility function returns NO data, as per the types indicate
+// if a response body is needed, we can implement a listener
+// response.on('data', cb)
+// which can append data to a buffer and return it
 function sendRequest(url: URL, options: RequestOptions, buffer?: Buffer): Promise<RequestResult> {
   return new Promise((resolve) => {
     const requestMethod = url.protocol === "https:" ? https.request : http.request;
 
     const request = requestMethod(options, (response) => {
       const statusCode = response.statusCode;
+
+      // https://nodejs.org/api/http.html#class-httpclientrequest
+      // "Until the data is consumed, the 'end' event will not fire. Also, until the data is read it will consume memory that can eventually lead to a 'process out of memory' error"
+      response.resume()
 
       if (statusCode === undefined || statusCode < 200 || statusCode > 299) {
         return resolve({
@@ -61,7 +69,7 @@ function sendRequest(url: URL, options: RequestOptions, buffer?: Buffer): Promis
       });
     });
 
-    request.on("error", (error) => {
+    request.once("error", (error) => {
       resolve({
         success: false,
         errorMessage: error.message,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -43,6 +43,8 @@ export function get(url: URL, options?: Partial<RequestOptions>): Promise<Reques
 // This utility function returns NO data, as per the types indicate
 // if a response body is needed, we can implement a listener
 // response.on('data', cb)
+// or call
+// response.read()
 // which can append data to a buffer and return it
 function sendRequest(url: URL, options: RequestOptions, buffer?: Buffer): Promise<RequestResult> {
   return new Promise((resolve) => {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fully fixes the FD leak by discarding the `response` stream using `resume()`
We already discard the result of any GET or POST here, and always have (which we know from the types returning only a status code), so `resume()` is fine here.

I was under the impression that since we did not provide `response.on('data', cb)` that this clause wouldn't apply and the response stream would be ignored:


>If no [`'response'`](https://nodejs.org/api/http.html#event-response) handler is added, then the response will be entirely discarded. However, if a [`'response'`](https://nodejs.org/api/http.html#event-response) event handler is added, then the data from the response object **must** be consumed, either by calling `response.read()` whenever there is a `'readable'` event, or by adding a `'data'` handler, or by calling the `.resume()` method. Until the data is consumed, the `'end'` event will not fire. Also, until the data is read it will consume memory that can eventually lead to a 'process out of memory' error.


but of course passing a callback function _counts_ as a `handler` so in this case the **must** clause counts and the underlying readable stream was never consumed, causing the FD leak.

This code has been present for many years but only became an issue in Node20. For that, I'm not exactly clear. But I can confirm this PR fixes the issue.

### Motivation

You can see the fix in this [notebook](https://ddserverless.datadoghq.com/notebook/7135653/aj-node20-file-descriptor-leak)

### Testing Guidelines


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
