### PR TITLE
fix: block forbidden chars from metric names

### DIFF
--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -115,6 +115,7 @@ export class ExtendedError extends Error {
 export class ImportModuleError extends ExtendedError {}
 export class HandlerNotFound extends ExtendedError {}
 export class MalformedHandlerName extends ExtendedError {}
+export class MalformedMetricName extends ExtendedError {}
 export class UserCodeSyntaxError extends ExtendedError {}
 export class UnhandledPromiseRejection extends ExtendedError {
   constructor(reason?: string, promise?: Promise<any>) {
@@ -128,6 +129,7 @@ const errorClasses = [
   ImportModuleError,
   HandlerNotFound,
   MalformedHandlerName,
+  MalformedMetricName,
   UserCodeSyntaxError,
   UnhandledPromiseRejection,
 ];


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Block calling metric functions with names that will cause `datadog-agent` to fail.

### Motivation

<!--- What inspired you to submit this pull request? --->

I should probably have known better, but it took me a merged PR all the way to prod and an error message in DataDog Serverless before I realized my code didn't work, and a clone of `datadog-agent` Go code to realize what I'd messed up. So I figured this could help other people.

### Testing Guidelines

<!--- How did you test this pull request? --->

I added a new Jest case.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

I guess this is technically a breaking change. But if anybody would be affected by it we'd really be doing them a favor here as they would still have errors in their logs, only further down the pipeline. 🤷🏻 

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
