### PR TITLE
fix: reading sampling priority will error when not available

### DIFF
--- a/src/trace/span-context-wrapper.spec.ts
+++ b/src/trace/span-context-wrapper.spec.ts
@@ -23,25 +23,31 @@ describe("SpanContextWrapper", () => {
 
   describe("sampleMode", () => {
     it("should return AUTO_KEEP when sampling priority is not available in spanContext", () => {
-      const spanContext = new SpanContextWrapper({
-        toSpanId: () => "1234",
-        toTraceId: () => "5678",
-        _sampling: {}
-      }, TraceSource.Event);
-  
-      const sampleMode = spanContext.sampleMode()
+      const spanContext = new SpanContextWrapper(
+        {
+          toSpanId: () => "1234",
+          toTraceId: () => "5678",
+          _sampling: {},
+        },
+        TraceSource.Event,
+      );
+
+      const sampleMode = spanContext.sampleMode();
       expect(sampleMode).toBe(SampleMode.AUTO_KEEP);
       expect(sampleMode.toString()).toBe("1");
-    })
+    });
 
     it("should return sampling priority when available in spanContext", () => {
-      const spanContext = new SpanContextWrapper({
-        toSpanId: () => "1234",
-        toTraceId: () => "5678",
-        _sampling: { priority: 2 }
-      }, TraceSource.Event);
-  
-      const sampleMode = spanContext.sampleMode()
+      const spanContext = new SpanContextWrapper(
+        {
+          toSpanId: () => "1234",
+          toTraceId: () => "5678",
+          _sampling: { priority: 2 },
+        },
+        TraceSource.Event,
+      );
+
+      const sampleMode = spanContext.sampleMode();
       expect(sampleMode).toBe(2);
       expect(sampleMode.toString()).toBe("2");
     });

--- a/src/trace/span-context-wrapper.spec.ts
+++ b/src/trace/span-context-wrapper.spec.ts
@@ -1,5 +1,5 @@
 import { SpanContextWrapper } from "./span-context-wrapper";
-import { TraceSource } from "./trace-context-service";
+import { SampleMode, TraceSource } from "./trace-context-service";
 
 describe("SpanContextWrapper", () => {
   beforeEach(() => {});
@@ -19,5 +19,31 @@ describe("SpanContextWrapper", () => {
     expect(spanContext?.source).toBe("event");
     expect(spanContext?.spanContext._traceId.toArray()).toEqual([121, 177, 18, 140, 107, 104, 185, 240]);
     expect(spanContext?.spanContext._spanId.toArray()).toEqual([96, 4, 217, 174, 182, 29, 220, 172]);
+  });
+
+  describe("sampleMode", () => {
+    it("should return AUTO_KEEP when sampling priority is not available in spanContext", () => {
+      const spanContext = new SpanContextWrapper({
+        toSpanId: () => "1234",
+        toTraceId: () => "5678",
+        _sampling: {}
+      }, TraceSource.Event);
+  
+      const sampleMode = spanContext.sampleMode()
+      expect(sampleMode).toBe(SampleMode.AUTO_KEEP);
+      expect(sampleMode.toString()).toBe("1");
+    })
+
+    it("should return sampling priority when available in spanContext", () => {
+      const spanContext = new SpanContextWrapper({
+        toSpanId: () => "1234",
+        toTraceId: () => "5678",
+        _sampling: { priority: 2 }
+      }, TraceSource.Event);
+  
+      const sampleMode = spanContext.sampleMode()
+      expect(sampleMode).toBe(2);
+      expect(sampleMode.toString()).toBe("2");
+    });
   });
 });

--- a/src/trace/span-context-wrapper.ts
+++ b/src/trace/span-context-wrapper.ts
@@ -1,5 +1,5 @@
 import { logDebug } from "../utils";
-import { TraceContext, TraceSource } from "./trace-context-service";
+import { SampleMode, TraceContext, TraceSource } from "./trace-context-service";
 import { SpanContext } from "./tracer-wrapper";
 
 /**
@@ -18,7 +18,7 @@ export class SpanContextWrapper implements SpanContext {
   }
 
   public sampleMode(): number {
-    return this.spanContext._sampling?.priority;
+    return this.spanContext._sampling?.priority ?? SampleMode.AUTO_KEEP;
   }
 
   public toString = (): string => {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes a bug in which reading sampling priority will cause an error, because it was undefined. Previously, before adding W3C, we'd just set always `AUTO_KEEP`, but now we decided on getting whatever the trace context had. 

Now, if not available, we'll go back to using `AUTO_KEEP`, while respecting whichever was there before if set.

### Motivation

#482 

### Testing Guidelines

Added unit tests.

### Additional Notes

Introduced in: https://github.com/DataDog/datadog-lambda-js/commit/f05c6003a4f7bab82e46e741ac8d0c98d89efe5b#diff-8367049249917f97a7d4b0d7aa3355ac631ce80bd38d35f0f04c9288c603b76a

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
