### PR TITLE
feat: Use mirror to fix rate limit issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@ ARG image
 FROM $image as builder
 ARG image
 
-# Install git so we can specify a specific git ref (ie: refs/head/my-feature) in package.json 
-# to install a specific dd-trace version for performance test
-RUN apk add git python3 make g++
-
 # Create the directory structure required for AWS Lambda Layer
 RUN mkdir -p /nodejs/node_modules/
 

--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -31,7 +31,7 @@ stages:
 build-layer ({{ $runtime.name }}):
   stage: build
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10
+  image: registry.ddbuild.io/images/mirror/docker:20.10
   artifacts:
     expire_in: 1 hr # Unsigned zips expire in 1 hour
     paths:
@@ -44,7 +44,7 @@ build-layer ({{ $runtime.name }}):
 check-layer-size ({{ $runtime.name }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10
+  image: registry.ddbuild.io/images/mirror/docker:20.10
   needs: 
     - build-layer ({{ $runtime.name }})
   dependencies:
@@ -76,7 +76,7 @@ unit-test ({{ $runtime.name }}):
 integration-test ({{ $runtime.name }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
   needs: 
     - build-layer ({{ $runtime.name }})
   dependencies:
@@ -98,7 +98,7 @@ integration-test ({{ $runtime.name }}):
 sign-layer ({{ $runtime.name }}):
   stage: sign
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: manual
@@ -125,7 +125,7 @@ sign-layer ({{ $runtime.name }}):
 publish-layer-{{ $environment.name }} ({{ $runtime.name }}):
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
   rules:
     - if: '"{{ $environment.name }}" =~ /^(sandbox|staging)/'
       when: manual
@@ -164,7 +164,7 @@ publish-layer-{{ $environment.name }} ({{ $runtime.name }}):
 publish-npm-package:
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
   cache: []
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'

--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -39,7 +39,7 @@ build-layer ({{ $runtime.name }}):
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
   script:
-    - NODE_VERSION={{ $runtime.node_major_version }} ./scripts/build_layers.sh
+    - NODE_VERSION={{ $runtime.node_version }} ./scripts/build_layers.sh
 
 check-layer-size ({{ $runtime.name }}):
   stage: test

--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -31,7 +31,7 @@ stages:
 build-layer ({{ $runtime.name }}):
   stage: build
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/docker:20.10
+  image: registry.ddbuild.io/images/docker:20.10
   artifacts:
     expire_in: 1 hr # Unsigned zips expire in 1 hour
     paths:
@@ -44,7 +44,7 @@ build-layer ({{ $runtime.name }}):
 check-layer-size ({{ $runtime.name }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/docker:20.10
+  image: registry.ddbuild.io/images/docker:20.10
   needs: 
     - build-layer ({{ $runtime.name }})
   dependencies:
@@ -76,7 +76,7 @@ unit-test ({{ $runtime.name }}):
 integration-test ({{ $runtime.name }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
+  image: registry.ddbuild.io/images/docker:20.10-py3
   needs: 
     - build-layer ({{ $runtime.name }})
   dependencies:
@@ -98,7 +98,7 @@ integration-test ({{ $runtime.name }}):
 sign-layer ({{ $runtime.name }}):
   stage: sign
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
+  image: registry.ddbuild.io/images/docker:20.10-py3
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: manual
@@ -125,7 +125,7 @@ sign-layer ({{ $runtime.name }}):
 publish-layer-{{ $environment.name }} ({{ $runtime.name }}):
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
+  image: registry.ddbuild.io/images/docker:20.10-py3
   rules:
     - if: '"{{ $environment.name }}" =~ /^(sandbox|staging)/'
       when: manual
@@ -164,7 +164,7 @@ publish-layer-{{ $environment.name }} ({{ $runtime.name }}):
 publish-npm-package:
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/docker:20.10-py3
+  image: registry.ddbuild.io/images/docker:20.10-py3
   cache: []
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'

--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -39,7 +39,7 @@ build-layer ({{ $runtime.name }}):
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
   script:
-    - NODE_VERSION={{ $runtime.node_version }} ./scripts/build_layers.sh
+    - NODE_VERSION={{ $runtime.node_major_version }} ./scripts/build_layers.sh
 
 check-layer-size ({{ $runtime.name }}):
   stage: test

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -11,7 +11,7 @@ set -e
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_node"
 
-export NODE_VERSIONS=("16" "18" "20")
+export NODE_VERSIONS=("16.14" "18.12" "20.9")
 
 if [ -z "$NODE_VERSION" ]; then
     echo "Node version not specified, running for all node versions."
@@ -33,12 +33,12 @@ function docker_build_zip {
     # Args: [node version] [zip destination]
 
     destination=$(make_path_absolute $2)
-
+    node_image_version=$(echo $1 | cut -d '.' -f 1)
     # Install datadog node in a docker container to avoid the mess from switching
     # between different node runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-layer-node:$1 . --no-cache \
-        --build-arg image=registry.ddbuild.io/images/mirror/node:$1-bullseye --progress=plain -o $temp_dir/nodejs
+        --build-arg image=registry.ddbuild.io/images/mirror/node:$node_image_version-bullseye --progress=plain -o $temp_dir/nodejs
 
     # Zip to destination, and keep directory structure as based in $temp_dir
     (cd $temp_dir && zip -q -r $destination ./)

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -38,7 +38,7 @@ function docker_build_zip {
     # between different node runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-layer-node:$1 . --no-cache \
-        --build-arg image=registry.ddbuild.io/images/mirror/node:$node_image_version-bullseye --progress=plain -o $temp_dir/nodejs
+        --build-arg image=registry.ddbuild.io/images/mirror/node:${node_image_version}-bullseye --progress=plain -o $temp_dir/nodejs
 
     # Zip to destination, and keep directory structure as based in $temp_dir
     (cd $temp_dir && zip -q -r $destination ./)

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -11,7 +11,7 @@ set -e
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_node"
 
-export NODE_VERSIONS=("16.14" "18.12" "20.9")
+export NODE_VERSIONS=("16" "18" "20")
 
 if [ -z "$NODE_VERSION" ]; then
     echo "Node version not specified, running for all node versions."
@@ -38,7 +38,7 @@ function docker_build_zip {
     # between different node runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-layer-node:$1 . --no-cache \
-        --build-arg image=node:$1-alpine --progress=plain -o $temp_dir/nodejs
+        --build-arg image=registry.ddbuild.io/images/mirror/node:$1-bullseye --progress=plain -o $temp_dir/nodejs
 
     # Zip to destination, and keep directory structure as based in $temp_dir
     (cd $temp_dir && zip -q -r $destination ./)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -16,7 +16,7 @@ do
     docker build -t datadog-lambda-layer-node-test:$node_version \
         -f scripts/Dockerfile_test . \
         --quiet \
-        --build-arg image=node:$node_version-alpine
+        --build-arg image=registry.ddbuild.io/images/mirror/node:$node_version-bullseye
     docker run --rm -v `pwd`:/datadog-lambda-layer-node \
         -w /datadog-lambda-layer-node \
         datadog-lambda-layer-node-test:$node_version \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -18,7 +18,7 @@ do
     docker build -t datadog-lambda-layer-node-test:$node_version \
         -f scripts/Dockerfile_test . \
         --quiet \
-        --build-arg image=registry.ddbuild.io/images/mirror/node:$node_major_version-bullseye
+        --build-arg image=registry.ddbuild.io/images/mirror/node:${node_major_version}-bullseye
     docker run --rm -v `pwd`:/datadog-lambda-layer-node \
         -w /datadog-lambda-layer-node \
         datadog-lambda-layer-node-test:$node_version \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,17 +6,19 @@
 # Copyright 2019 Datadog, Inc.
 
 # Run unit tests in Docker
+# For local use only
 set -e
 
 NODE_VERSIONS=("16.14" "18.12" "20.9")
 
 for node_version in "${NODE_VERSIONS[@]}"
 do
+    node_major_version=$(echo $node_version | cut -d '.' -f 1)
     echo "Running tests against node${node_version}"
     docker build -t datadog-lambda-layer-node-test:$node_version \
         -f scripts/Dockerfile_test . \
         --quiet \
-        --build-arg image=registry.ddbuild.io/images/mirror/node:$node_version-bullseye
+        --build-arg image=registry.ddbuild.io/images/mirror/node:$node_major_version-bullseye
     docker run --rm -v `pwd`:/datadog-lambda-layer-node \
         -w /datadog-lambda-layer-node \
         datadog-lambda-layer-node-test:$node_version \


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Build and integration tests occasionally fail with rate limit errors, because I used the wrong URL:
![image](https://github.com/DataDog/datadog-lambda-js/assets/1598537/5f4a5f94-404a-48c7-8862-46ac20b66932)

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
