### PR TITLE
fix: release script should exit on error.

### DIFF
--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -14,6 +14,7 @@ stages:
   - apt-get update
   - apt-get install nodejs -y
   - npm install --global yarn
+  - npm install --global tsc
 
 .node-before-script: &node-before-script
   - echo 'yarn-offline-mirror ".yarn-cache/"' >> .yarnrc

--- a/ci/publish_npm.sh
+++ b/ci/publish_npm.sh
@@ -5,6 +5,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2023 Datadog, Inc.
 
+set -e
+
 NPM_TOKEN=$(aws ssm get-parameter \
     --region us-east-1 \
     --name "ci.datadog-lambda-js.npm-token" \


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Prevents #503.

The new ci-based release logic never used `set -e`, and thus when `tsc` wasn't found, it published the typescript code (but not js) to npm:
![image](https://github.com/DataDog/datadog-lambda-js/assets/1598537/907cf614-4baf-4ef9-aeef-8c193b715d15)

This PR should fix that, and installs tsc correctly.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
