### PR TITLE
Extract trace context from AWSTraceHeader in SQS java upstream case

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "bignumber.js": "^9.0.1",
     "dc-polyfill": "^0.1.3",
     "hot-shots": "8.5.0",
     "promise-retry": "^2.0.1",

--- a/src/trace/context/extractors/sqs.ts
+++ b/src/trace/context/extractors/sqs.ts
@@ -3,18 +3,29 @@ import { EventTraceExtractor } from "../extractor";
 import { TracerWrapper } from "../../tracer-wrapper";
 import { logDebug } from "../../../utils";
 import { SpanContextWrapper } from "../../span-context-wrapper";
+import { XrayService } from "../../xray-service";
 
 export class SQSEventTraceExtractor implements EventTraceExtractor {
   constructor(private tracerWrapper: TracerWrapper) {}
 
   extract(event: SQSEvent): SpanContextWrapper | null {
-    const headers = event?.Records?.[0]?.messageAttributes?._datadog?.stringValue;
-    if (headers === undefined) return null;
-
     try {
-      const traceContext = this.tracerWrapper.extract(JSON.parse(headers));
-      if (traceContext === null) return null;
+      var prepared_headers;
+      const headers = event?.Records?.[0]?.messageAttributes?._datadog?.stringValue;
+      if (headers !== undefined) {
+        prepared_headers = JSON.parse(headers);
+      } else {
+        if (event?.Records?.[0]?.attributes?.AWSTraceHeader) {
+          prepared_headers = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
+        }
+      }
 
+      if (!prepared_headers) return null;
+      const traceContext = this.tracerWrapper.extract(prepared_headers);
+      if (traceContext === null) {
+        logDebug("Unable to extract the injected trace context from event");
+        return null;
+      }
       logDebug(`Extracted trace context from SQS event`, { traceContext, event });
       return traceContext;
     } catch (error) {

--- a/src/trace/context/extractors/sqs.ts
+++ b/src/trace/context/extractors/sqs.ts
@@ -10,20 +10,20 @@ export class SQSEventTraceExtractor implements EventTraceExtractor {
 
   extract(event: SQSEvent): SpanContextWrapper | null {
     try {
-      let preparedHeaders;
+      let parsedHeaders;
       const headers = event?.Records?.[0]?.messageAttributes?._datadog?.stringValue;
       if (headers !== undefined) {
-        preparedHeaders = JSON.parse(headers);
+        parsedHeaders = JSON.parse(headers);
       } else {
         if (event?.Records?.[0]?.attributes?.AWSTraceHeader) {
-          preparedHeaders = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
+          parsedHeaders = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
         }
       }
 
-      if (!preparedHeaders) return null;
-      const traceContext = this.tracerWrapper.extract(preparedHeaders);
+      if (!parsedHeaders) return null;
+      const traceContext = this.tracerWrapper.extract(parsedHeaders);
       if (traceContext === null) {
-        logDebug(`Failed to extract trace context from prepared headers: ${preparedHeaders}`);
+        logDebug(`Failed to extract trace context from prepared headers: ${parsedHeaders}`);
         return null;
       }
       logDebug(`Extracted trace context from SQS event`, { traceContext, event });

--- a/src/trace/context/extractors/sqs.ts
+++ b/src/trace/context/extractors/sqs.ts
@@ -14,19 +14,18 @@ export class SQSEventTraceExtractor implements EventTraceExtractor {
       const headers = event?.Records?.[0]?.messageAttributes?._datadog?.stringValue;
       if (headers !== undefined) {
         parsedHeaders = JSON.parse(headers);
-      } else {
-        if (event?.Records?.[0]?.attributes?.AWSTraceHeader) {
-          parsedHeaders = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
-        }
+      } else if (event?.Records?.[0]?.attributes?.AWSTraceHeader !== undefined) {
+        parsedHeaders = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
       }
-
       if (!parsedHeaders) return null;
+
       const traceContext = this.tracerWrapper.extract(parsedHeaders);
       if (traceContext === null) {
-        logDebug(`Failed to extract trace context from prepared headers: ${parsedHeaders}`);
+        logDebug("Failed to extract trace context from parsed headers", { parsedHeaders, event });
         return null;
       }
-      logDebug(`Extracted trace context from SQS event`, { traceContext, event });
+
+      logDebug("Extracted trace context from SQS event", { traceContext, event });
       return traceContext;
     } catch (error) {
       if (error instanceof Error) {

--- a/src/trace/context/extractors/sqs.ts
+++ b/src/trace/context/extractors/sqs.ts
@@ -10,20 +10,20 @@ export class SQSEventTraceExtractor implements EventTraceExtractor {
 
   extract(event: SQSEvent): SpanContextWrapper | null {
     try {
-      var prepared_headers;
+      let preparedHeaders;
       const headers = event?.Records?.[0]?.messageAttributes?._datadog?.stringValue;
       if (headers !== undefined) {
-        prepared_headers = JSON.parse(headers);
+        preparedHeaders = JSON.parse(headers);
       } else {
         if (event?.Records?.[0]?.attributes?.AWSTraceHeader) {
-          prepared_headers = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
+          preparedHeaders = XrayService.extraceDDContextFromAWSTraceHeader(event.Records[0].attributes.AWSTraceHeader);
         }
       }
 
-      if (!prepared_headers) return null;
-      const traceContext = this.tracerWrapper.extract(prepared_headers);
+      if (!preparedHeaders) return null;
+      const traceContext = this.tracerWrapper.extract(preparedHeaders);
       if (traceContext === null) {
-        logDebug("Unable to extract the injected trace context from event");
+        logDebug(`Failed to extract trace context from prepared headers: ${preparedHeaders}`);
         return null;
       }
       logDebug(`Extracted trace context from SQS event`, { traceContext, event });

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -201,7 +201,7 @@ export class XrayService {
     try {
       return (BigInt("0x" + lastPart) % BigInt("0x8000000000000000")).toString(10); // mod by 2^63 will leave us with the last 63 bits
     } catch (_) {
-      logDebug(`Faied to convert trace id ${lastPart}`);
+      logDebug(`Failed to convert Xray Trace Id ${lastPart}`);
       return undefined;
     }
   }

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -75,6 +75,7 @@ export class XrayService {
     });
   }
 
+  // Example: Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1
   public static parseAWSTraceHeader(awsTraceHeader: string): XrayTraceHeader | undefined {
     const [root, parent, _sampled] = awsTraceHeader.split(";");
     if (parent === undefined || _sampled === undefined) return;

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -185,7 +185,7 @@ export class XrayService {
     try {
       return BigInt("0x" + xrayParentId).toString(10);
     } catch (_) {
-      logDebug(`Faied to convert xray parent id ${xrayParentId}`);
+      logDebug(`Failed to convert Xray Parent Id ${xrayParentId}`);
       return undefined;
     }
   }

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -184,6 +184,7 @@ export class XrayService {
     try {
       return BigInt("0x" + xrayParentId).toString(10);
     } catch (_) {
+      logDebug(`Faied to convert xray parent id ${xrayParentId}`);
       return undefined;
     }
   }

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -1,10 +1,15 @@
 import { randomBytes } from "crypto";
 import { logDebug } from "../utils";
 import { SampleMode, TraceContext, TraceSource } from "./trace-context-service";
-import BigNumber from "bignumber.js";
 import { Socket, createSocket } from "dgram";
 import { SpanContextWrapper } from "./span-context-wrapper";
 import { StepFunctionContext } from "./step-function-service";
+import {
+  DATADOG_TRACE_ID_HEADER,
+  DATADOG_PARENT_ID_HEADER,
+  DATADOG_SAMPLING_PRIORITY_HEADER,
+  DatadogTraceHeaders,
+} from "./context/extractor";
 
 const AMZN_TRACE_ID_ENV_VAR = "_X_AMZN_TRACE_ID";
 const AWS_XRAY_DAEMON_ADDRESS_ENV_VAR = "AWS_XRAY_DAEMON_ADDRESS";
@@ -70,16 +75,8 @@ export class XrayService {
     });
   }
 
-  private parseTraceContextHeader(): XrayTraceHeader | undefined {
-    const header = process.env[AMZN_TRACE_ID_ENV_VAR];
-    if (header === undefined) {
-      logDebug("Couldn't read Xray trace header from env");
-      return;
-    }
-
-    // Example: Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1
-    logDebug(`Reading Xray trace context from env var ${header}`);
-    const [root, parent, _sampled] = header.split(";");
+  public static parseAWSTraceHeader(awsTraceHeader: string): XrayTraceHeader | undefined {
+    const [root, parent, _sampled] = awsTraceHeader.split(";");
     if (parent === undefined || _sampled === undefined) return;
 
     const [, traceId] = root.split("=");
@@ -92,6 +89,18 @@ export class XrayService {
       parentId,
       sampled,
     };
+  }
+
+  private parseTraceContextHeader(): XrayTraceHeader | undefined {
+    const header = process.env[AMZN_TRACE_ID_ENV_VAR];
+    if (header === undefined) {
+      logDebug("Couldn't read Xray trace header from env");
+      return;
+    }
+
+    // Example: Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1
+    logDebug(`Reading Xray trace context from env var ${header}`);
+    return XrayService.parseAWSTraceHeader(header);
   }
 
   private convertToSampleMode(xraySampled: number): SampleMode {
@@ -172,11 +181,11 @@ export class XrayService {
 
   private convertToParentId(xrayParentId: string): string | undefined {
     if (xrayParentId.length !== 16) return;
-
-    const hex = new BigNumber(xrayParentId, 16);
-    if (hex.isNaN()) return;
-
-    return hex.toString(10);
+    try {
+      return BigInt("0x" + xrayParentId).toString(10);
+    } catch (_) {
+      return undefined;
+    }
   }
 
   private convertToTraceId(xrayTraceId: string): string | undefined {
@@ -187,13 +196,29 @@ export class XrayService {
     if (lastPart.length !== 24) return;
 
     // We want to turn the last 63 bits into a decimal number in a string representation
-    // Unfortunately, all numbers in javascript are represented by float64 bit numbers, which
-    // means we can't parse 64 bit integers accurately.
-    const hex = new BigNumber(lastPart, 16);
-    if (hex.isNaN()) return;
+    try {
+      return (BigInt("0x" + lastPart) % BigInt("0x8000000000000000")).toString(10);
+    } catch (_) {
+      return undefined;
+    }
+  }
 
-    // Toggle off the 64th bit
-    const last63Bits = hex.mod(new BigNumber("8000000000000000", 16));
-    return last63Bits.toString(10);
+  public static extraceDDContextFromAWSTraceHeader(amznTraceId: string): DatadogTraceHeaders | null {
+    var aws_context = XrayService.parseAWSTraceHeader(amznTraceId);
+    if (!aws_context) {
+      return null;
+    }
+    const trace_id_parts = aws_context.traceId.split("-");
+    if (trace_id_parts && trace_id_parts.length > 2 && trace_id_parts[2].startsWith("00000000")) {
+      // This AWSTraceHeader contains Datadog injected trace context
+      return {
+        [DATADOG_TRACE_ID_HEADER]: hexStrToDecimalStr(trace_id_parts[2].substring(8)),
+        [DATADOG_PARENT_ID_HEADER]: hexStrToDecimalStr(aws_context.parentId),
+        [DATADOG_SAMPLING_PRIORITY_HEADER]: aws_context.sampled,
+      };
+    }
+    return null;
   }
 }
+
+const hexStrToDecimalStr = (hexString: string): string => BigInt("0x" + hexString).toString(10);

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -208,7 +208,7 @@ export class XrayService {
 
   public static extraceDDContextFromAWSTraceHeader(amznTraceId: string): DatadogTraceHeaders | null {
     const awsContext = XrayService.parseAWSTraceHeader(amznTraceId);
-    if (!awsContext) {
+    if (awsContext === undefined) {
       return null;
     }
     const traceIdParts = awsContext.traceId.split("-");

--- a/src/trace/xray-service.ts
+++ b/src/trace/xray-service.ts
@@ -13,7 +13,7 @@ import {
 
 const AMZN_TRACE_ID_ENV_VAR = "_X_AMZN_TRACE_ID";
 const AWS_XRAY_DAEMON_ADDRESS_ENV_VAR = "AWS_XRAY_DAEMON_ADDRESS";
-
+const DD_TRACE_JAVA_TRACE_ID_PADDING = "00000000";
 interface XrayTraceHeader {
   traceId: string;
   parentId: string;
@@ -212,7 +212,7 @@ export class XrayService {
       return null;
     }
     const traceIdParts = awsContext.traceId.split("-");
-    if (traceIdParts && traceIdParts.length > 2 && traceIdParts[2].startsWith("00000000")) {
+    if (traceIdParts && traceIdParts.length > 2 && traceIdParts[2].startsWith(DD_TRACE_JAVA_TRACE_ID_PADDING)) {
       // This AWSTraceHeader contains Datadog injected trace context
       return {
         [DATADOG_TRACE_ID_HEADER]: hexStrToDecimalStr(traceIdParts[2].substring(8)),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
In the case where 
Java lambda ==> SQS ==> NodeJS lambda
the tracecontext is injected into the `Records[i].attributes.AWSTraceHeader`.
This PR refactors around XRayService and SQSEventTraceExtractor to extract that context out.
Result:
<img width="1340" alt="Screenshot 2024-03-14 at 2 27 50 PM" src="https://github.com/DataDog/datadog-lambda-js/assets/5253430/afcc5223-737e-40a4-9a6f-39de05c83d8a">


<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
