### PR TITLE
Favor parameterized routes for resource name.

### DIFF
--- a/event_samples/api-gateway-v1-parametrized.json
+++ b/event_samples/api-gateway-v1-parametrized.json
@@ -1,0 +1,111 @@
+{
+  "resource": "/user/{id}",
+  "path": "/user/42",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "*/*",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-ASN": "7922",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com",
+    "User-Agent": "curl/8.1.2",
+    "Via": "2.0 xxx.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "Tz3yUVcJkwOhQGqZgKTzrEHqAoOd8ZprYAHpg2S6BNxdd-Ym79pb6g==",
+    "X-Amzn-Trace-Id": "Root=1-65f49d20-7ba106216238dd0078a5db31",
+    "X-Forwarded-For": "76.115.124.192, 15.158.54.119",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "*/*"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-ASN": [
+      "7922"
+    ],
+    "CloudFront-Viewer-Country": [
+      "US"
+    ],
+    "Host": [
+      "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com"
+    ],
+    "User-Agent": [
+      "curl/8.1.2"
+    ],
+    "Via": [
+      "2.0 xxx.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "Tz3yUVcJkwOhQGqZgKTzrEHqAoOd8ZprYAHpg2S6BNxdd-Ym79pb6g=="
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-65f49d20-7ba106216238dd0078a5db31"
+    ],
+    "X-Forwarded-For": [
+      "76.115.124.192, 15.158.54.119"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": {
+    "id": "42"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "ojg3nk",
+    "resourcePath": "/user/{id}",
+    "httpMethod": "GET",
+    "extendedRequestId": "Ur19IHYDmjQEU5A=",
+    "requestTime": "15/Mar/2024:19:10:24 +0000",
+    "path": "/dev/user/42",
+    "accountId": "425362996713",
+    "protocol": "HTTP/1.1",
+    "stage": "dev",
+    "domainPrefix": "mcwkra0ya4",
+    "requestTimeEpoch": 1710529824520,
+    "requestId": "e16399f7-e984-463a-9931-745ba021a27f",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "76.115.124.192",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "curl/8.1.2",
+      "user": null
+    },
+    "domainName": "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com",
+    "apiId": "mcwkra0ya4"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/event_samples/api-gateway-v2-parametrized.json
+++ b/event_samples/api-gateway-v2-parametrized.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0",
+  "routeKey": "GET /user/{id}",
+  "rawPath": "/user/42",
+  "rawQueryString": "",
+  "headers": {
+    "accept": "*/*",
+    "content-length": "0",
+    "host": "9vj54we5ih.execute-api.sa-east-1.amazonaws.com",
+    "user-agent": "curl/8.1.2",
+    "x-amzn-trace-id": "Root=1-65f49d71-505edb3b69b8abd513cfa08b",
+    "x-forwarded-for": "76.115.124.192",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "requestContext": {
+    "accountId": "425362996713",
+    "apiId": "9vj54we5ih",
+    "domainName": "9vj54we5ih.execute-api.sa-east-1.amazonaws.com",
+    "domainPrefix": "9vj54we5ih",
+    "http": {
+      "method": "GET",
+      "path": "/user/42",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "76.115.124.192",
+      "userAgent": "curl/8.1.2"
+    },
+    "requestId": "Ur2JtjEfGjQEPOg=",
+    "routeKey": "GET /user/{id}",
+    "stage": "$default",
+    "time": "15/Mar/2024:19:11:45 +0000",
+    "timeEpoch": 1710529905066
+  },
+  "pathParameters": {
+    "id": "42"
+  },
+  "isBase64Encoded": false
+}

--- a/src/trace/span-inferrer.spec.ts
+++ b/src/trace/span-inferrer.spec.ts
@@ -12,6 +12,8 @@ const eventBridgeSQSEvent = require("../../event_samples/eventbridge-sqs.json");
 const webSocketEvent = require("../../event_samples/api-gateway-wss.json");
 const apiGatewayV1 = require("../../event_samples/api-gateway-v1.json");
 const apiGatewayV2 = require("../../event_samples/api-gateway-v2.json");
+const apiGatewayV1Parametrized = require("../../event_samples/api-gateway-v1-parametrized.json");
+const apiGatewayV2Parametrized = require("../../event_samples/api-gateway-v2-parametrized.json");
 const apiGatewayV1RequestAuthorizer = require("../../event_samples/api-gateway-traced-authorizer-request-v1.json");
 const apiGatewayV1RequestAuthorizerCached = require("../../event_samples/api-gateway-traced-authorizer-request-v1-cached.json");
 const apiGatewayV1TokenAuthorizer = require("../../event_samples/api-gateway-traced-authorizer-token-v1.json");
@@ -709,6 +711,60 @@ describe("SpanInferrer", () => {
         "service.name": "r3pmxmplak.execute-api.us-east-2.amazonaws.com",
         "span.type": "http",
         stage: "default",
+      },
+    });
+  });
+
+  it("creates an inferred span for API Gateway V1 events with parameters", () => {
+    const inferrer = new SpanInferrer(mockWrapper as unknown as TracerWrapper);
+    inferrer.createInferredSpan(apiGatewayV1Parametrized, {} as any, {} as SpanContext);
+
+    expect(mockWrapper.startSpan).toBeCalledWith("aws.apigateway", {
+      childOf: {},
+      startTime: 1710529824520,
+      tags: {
+        _inferred_span: { synchronicity: "sync", tag_source: "self" },
+        apiid: "mcwkra0ya4",
+        endpoint: "/dev/user/42",
+        "http.url": "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com/dev/user/42",
+        domain_name: "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com",
+        operation_name: "aws.apigateway",
+        "peer.service": "mock-lambda-service",
+        request_id: undefined,
+        "http.method": "GET",
+        "resource.name": "GET /user/{id}",
+        resource_names: "GET /user/{id}",
+        service: "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com",
+        "service.name": "mcwkra0ya4.execute-api.sa-east-1.amazonaws.com",
+        "span.type": "http",
+        stage: "dev",
+      },
+    });
+  });
+
+  it("creates an inferred span for API Gateway V2 events with parameters", () => {
+    const inferrer = new SpanInferrer(mockWrapper as unknown as TracerWrapper);
+    inferrer.createInferredSpan(apiGatewayV2Parametrized, {} as any, {} as SpanContext);
+
+    expect(mockWrapper.startSpan).toBeCalledWith("aws.apigateway", {
+      childOf: {},
+      startTime: 1710529905066,
+      tags: {
+        _inferred_span: { synchronicity: "sync", tag_source: "self" },
+        apiid: "9vj54we5ih",
+        endpoint: "/user/42",
+        "http.url": "9vj54we5ih.execute-api.sa-east-1.amazonaws.com/user/42",
+        domain_name: "9vj54we5ih.execute-api.sa-east-1.amazonaws.com",
+        operation_name: "aws.apigateway",
+        "peer.service": "mock-lambda-service",
+        request_id: undefined,
+        "http.method": "GET",
+        "resource.name": "GET /user/{id}",
+        resource_names: "GET /user/{id}",
+        service: "9vj54we5ih.execute-api.sa-east-1.amazonaws.com",
+        "service.name": "9vj54we5ih.execute-api.sa-east-1.amazonaws.com",
+        "span.type": "http",
+        stage: "$default",
       },
     });
   });

--- a/src/trace/span-inferrer.ts
+++ b/src/trace/span-inferrer.ts
@@ -525,7 +525,7 @@ export class SpanInferrer {
   }
 
   getResourcePath(event: any): string {
-    const routeKey = event.requestContext.routeKey;
+    const routeKey = event?.requestContext?.routeKey;
     if (routeKey && routeKey.includes("{")) {
       // this is a parameterized route
       try {

--- a/src/trace/span-inferrer.ts
+++ b/src/trace/span-inferrer.ts
@@ -94,15 +94,7 @@ export class SpanInferrer {
     const options: SpanOptions = {};
     const domain = event.requestContext.domainName || "";
     const path = event.rawPath || event.requestContext.path || event.requestContext.routeKey;
-    var resourcePath = event.rawPath || event.requestContext.resourcePath || event.requestContext.routeKey;
-    if (event.requestContext.routeKey && event.requestContext.routeKey.includes("{")) {
-        // this is a parameterized route
-        try {
-            resourcePath = event.requestContext.routeKey.split(" ")[1];
-        } catch (e) {
-            logDebug("Error parsing routeKey", e as Error);
-        }
-    }
+    const resourcePath = this.getResourcePath(event);
 
     let method;
     if (event.requestContext.httpMethod) {
@@ -530,5 +522,18 @@ export class SpanInferrer {
       isAsync: true,
     };
     return new SpanWrapper(this.traceWrapper.startSpan("aws.eventbridge", options), spanWrapperOptions);
+  }
+
+  getResourcePath(event: any): string {
+    const routeKey = event.requestContext.routeKey;
+    if (routeKey && routeKey.includes("{")) {
+      // this is a parameterized route
+      try {
+        return event.requestContext.routeKey.split(" ")[1];
+      } catch (e) {
+        logDebug("Error parsing routeKey", e as Error);
+      }
+    }
+    return event.rawPath || event.requestContext.resourcePath || routeKey;
   }
 }

--- a/src/trace/span-inferrer.ts
+++ b/src/trace/span-inferrer.ts
@@ -94,7 +94,15 @@ export class SpanInferrer {
     const options: SpanOptions = {};
     const domain = event.requestContext.domainName || "";
     const path = event.rawPath || event.requestContext.path || event.requestContext.routeKey;
-    const resourcePath = event.rawPath || event.requestContext.resourcePath || event.requestContext.routeKey;
+    var resourcePath = event.rawPath || event.requestContext.resourcePath || event.requestContext.routeKey;
+    if (event.requestContext.routeKey && event.requestContext.routeKey.includes("{")) {
+        // this is a parameterized route
+        try {
+            resourcePath = event.requestContext.routeKey.split(" ")[1];
+        } catch (e) {
+            logDebug("Error parsing routeKey", e as Error);
+        }
+    }
 
     let method;
     if (event.requestContext.httpMethod) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Set the resource name to the parameterized route key when using api gateway v2.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

A metric is created from each span made by the tracers. The metric name comes from the operation name. The resource name gets added as a tag. Therefore unbound values for resource name can cause a large increase in the number of metrics on an account.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

To test this, I created two apps and pulled the event payloads for each to use in the unit tests.

```yaml
functions:
  v1:
    handler: handler.handler
    events:
      - http:
          method: get
          path: /user/{id}
  v2:
    handler: handler.handler
    events:
      - httpApi:
          method: get
          path: /user/{id}
```

<!--- How did you test this pull request? --->

### Additional Notes

This feature already worked for api gatewawy v1.

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
