### PR TITLE
chore: rename Agent to Extension

### DIFF
--- a/src/metrics/extension.spec.ts
+++ b/src/metrics/extension.spec.ts
@@ -1,9 +1,9 @@
 import nock from "nock";
 
-import { isAgentRunning, flushExtension, AGENT_URL } from "./extension";
+import { isExtensionRunning, flushExtension, EXTENSION_URL } from "./extension";
 import mock from "mock-fs";
 
-describe("isAgentRunning", () => {
+describe("isExtensionRunning", () => {
   afterEach(() => {
     mock.restore();
   });
@@ -11,25 +11,25 @@ describe("isAgentRunning", () => {
     mock({
       "/opt/extensions/datadog-agent": Buffer.from([0]),
     });
-    const ran = await isAgentRunning();
+    const ran = await isExtensionRunning();
     expect(ran).toBeTruthy();
   });
   it("returns false when agent doesn't exist", async () => {
     mock({});
-    const scope = nock(AGENT_URL).get("/lambda/hello").replyWithError("Unreachable");
-    const ran = await isAgentRunning();
+    const scope = nock(EXTENSION_URL).get("/lambda/hello").replyWithError("Unreachable");
+    const ran = await isExtensionRunning();
     expect(scope.isDone()).toBeFalsy();
     expect(ran).toBeFalsy();
   });
 });
 describe("flushExtension", () => {
   it("calls flush on the agent", async () => {
-    const scope = nock(AGENT_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
+    const scope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     await flushExtension();
     expect(scope.isDone()).toBeTruthy();
   });
   it("catches error when flush doesn't respond", async () => {
-    const scope = nock(AGENT_URL).post("/lambda/flush", JSON.stringify({})).replyWithError("Unavailable");
+    const scope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).replyWithError("Unavailable");
     await flushExtension();
     expect(scope.isDone()).toBeTruthy();
   });

--- a/src/metrics/extension.spec.ts
+++ b/src/metrics/extension.spec.ts
@@ -7,14 +7,14 @@ describe("isExtensionRunning", () => {
   afterEach(() => {
     mock.restore();
   });
-  it("returns true when agent exists and responds", async () => {
+  it("returns true when extension exists and responds", async () => {
     mock({
       "/opt/extensions/datadog-agent": Buffer.from([0]),
     });
     const ran = await isExtensionRunning();
     expect(ran).toBeTruthy();
   });
-  it("returns false when agent doesn't exist", async () => {
+  it("returns false when extension doesn't exist", async () => {
     mock({});
     const scope = nock(EXTENSION_URL).get("/lambda/hello").replyWithError("Unreachable");
     const ran = await isExtensionRunning();
@@ -23,7 +23,7 @@ describe("isExtensionRunning", () => {
   });
 });
 describe("flushExtension", () => {
-  it("calls flush on the agent", async () => {
+  it("calls flush on the extension", async () => {
     const scope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     await flushExtension();
     expect(scope.isDone()).toBeTruthy();

--- a/src/metrics/extension.ts
+++ b/src/metrics/extension.ts
@@ -10,7 +10,7 @@ const LOCAL_FLUSH_TIMEOUT_MS = 100;
 export async function isExtensionRunning() {
   const extensionExists = await fileExists(EXTENSION_PATH);
   if (!extensionExists) {
-    logDebug(`Agent isn't present in sandbox`);
+    logDebug(`Extension Layer is not present`);
     return false;
   }
   return true;

--- a/src/metrics/extension.ts
+++ b/src/metrics/extension.ts
@@ -2,12 +2,12 @@ import { URL } from "url";
 import { post, logDebug, logError } from "../utils";
 import fs from "fs";
 
-export const AGENT_URL = "http://127.0.0.1:8124";
-const FLUSH_PATH = "/lambda/flush";
+export const EXTENSION_URL = "http://127.0.0.1:8124";
 const EXTENSION_PATH = "/opt/extensions/datadog-agent";
-const AGENT_TIMEOUT_MS = 100;
+const LOCAL_FLUSH_PATH = "/lambda/flush";
+const LOCAL_FLUSH_TIMEOUT_MS = 100;
 
-export async function isAgentRunning() {
+export async function isExtensionRunning() {
   const extensionExists = await fileExists(EXTENSION_PATH);
   if (!extensionExists) {
     logDebug(`Agent isn't present in sandbox`);
@@ -17,8 +17,8 @@ export async function isAgentRunning() {
 }
 
 export async function flushExtension(): Promise<boolean> {
-  const url = new URL(FLUSH_PATH, AGENT_URL);
-  const result = await post(url, {}, { timeout: AGENT_TIMEOUT_MS });
+  const url = new URL(LOCAL_FLUSH_PATH, EXTENSION_URL);
+  const result = await post(url, {}, { timeout: LOCAL_FLUSH_TIMEOUT_MS });
   if (!result.success) {
     logError(`Failed to flush extension. ${result.errorMessage}`);
     return false;

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -2,7 +2,7 @@ import nock from "nock";
 import mock from "mock-fs";
 
 import { LogLevel, setLogLevel } from "../utils";
-import { AGENT_URL } from "./extension";
+import { EXTENSION_URL } from "./extension";
 
 import { MetricsListener } from "./listener";
 import StatsDClient from "hot-shots";
@@ -105,7 +105,7 @@ describe("MetricsListener", () => {
     expect(spy).toHaveBeenCalledWith(`{"e":1487076708,"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
   });
   it("always sends metrics to statsD when extension is enabled, ignoring logForwarding=true", async () => {
-    const flushScope = nock(AGENT_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
+    const flushScope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     mock({
       "/opt/extensions/datadog-agent": Buffer.from([0]),
     });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Renames `agent` to `extension` in `extension.ts` and some other files.

### Motivation

Just because.

### Testing Guidelines

N/A

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
