### PR TITLE
[SVLS-4422] Support metrics with timestamps when the Extension is running

### DIFF
--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -161,7 +161,7 @@ describe("MetricsListener", () => {
       apiKey: "api-key",
       apiKeyKMS: "",
       enhancedMetrics: false,
-      logForwarding: true,
+      logForwarding: false,
       shouldRetryMetrics: false,
       localTesting: true,
       siteURL,

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -137,6 +137,44 @@ describe("MetricsListener", () => {
     expect(flushScope.isDone()).toBeTruthy();
     expect(distributionMock).toHaveBeenCalledWith("my-metric", 10, undefined, ["tag:a", "tag:b"]);
   });
+  
+  it("only sends metrics with timestamps to the API when the extension is enabled", async () => {
+    const flushScope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
+    mock({
+      "/opt/extensions/datadog-agent": Buffer.from([0]),
+    });
+    nock("https://api.example.com").post("/api/v1/distribution_points?api_key=api-key").reply(200, {});
+
+    const distributionMock = jest.fn();
+    (StatsDClient as any).mockImplementation(() => {
+      return {
+        distribution: distributionMock,
+        close: (callback: any) => callback(undefined),
+      };
+    });
+
+    jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
+
+    const metricTimeOneMinuteAgo = new Date(Date.now() - 60000)
+    const kms = new MockKMS("kms-api-key-decrypted");
+    const listener = new MetricsListener(kms as any, {
+      apiKey: "api-key",
+      apiKeyKMS: "",
+      enhancedMetrics: false,
+      logForwarding: true,
+      shouldRetryMetrics: false,
+      localTesting: true,
+      siteURL,
+    });
+
+    await listener.onStartInvocation({});
+    listener.sendDistributionMetricWithDate("my-metric-with-a-timestamp", 10, metricTimeOneMinuteAgo, false, "tag:a", "tag:b");
+    listener.sendDistributionMetric("my-metric-without-a-timestamp", 10, false, "tag:a", "tag:b");
+    await listener.onCompleteInvocation();
+    expect(flushScope.isDone()).toBeTruthy();
+    expect(nock.isDone()).toBeTruthy();
+    expect(distributionMock).toHaveBeenCalledWith("my-metric-without-a-timestamp", 10, undefined, ["tag:a", "tag:b"]);
+  });
 
   it("logs metrics when logForwarding is enabled with custom timestamp", async () => {
     const spy = jest.spyOn(process.stdout, "write");

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -137,7 +137,7 @@ describe("MetricsListener", () => {
     expect(flushScope.isDone()).toBeTruthy();
     expect(distributionMock).toHaveBeenCalledWith("my-metric", 10, undefined, ["tag:a", "tag:b"]);
   });
-  
+
   it("only sends metrics with timestamps to the API when the extension is enabled", async () => {
     const flushScope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     mock({
@@ -155,7 +155,7 @@ describe("MetricsListener", () => {
 
     jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
 
-    const metricTimeOneMinuteAgo = new Date(Date.now() - 60000)
+    const metricTimeOneMinuteAgo = new Date(Date.now() - 60000);
     const kms = new MockKMS("kms-api-key-decrypted");
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
@@ -168,7 +168,14 @@ describe("MetricsListener", () => {
     });
 
     await listener.onStartInvocation({});
-    listener.sendDistributionMetricWithDate("my-metric-with-a-timestamp", 10, metricTimeOneMinuteAgo, false, "tag:a", "tag:b");
+    listener.sendDistributionMetricWithDate(
+      "my-metric-with-a-timestamp",
+      10,
+      metricTimeOneMinuteAgo,
+      false,
+      "tag:a",
+      "tag:b",
+    );
     listener.sendDistributionMetric("my-metric-without-a-timestamp", 10, false, "tag:a", "tag:b");
     await listener.onCompleteInvocation();
     expect(flushScope.isDone()).toBeTruthy();

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -153,7 +153,7 @@ export class MetricsListener {
           processor.addMetric(dist);
         });
         return;
-      };
+      }
 
       this.statsDClient?.distribution(name, value, undefined, tags);
       return;

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -131,7 +131,7 @@ export class MetricsListener {
   public sendDistributionMetricWithDate(
     name: string,
     value: number,
-    metricTime: Date,
+    metricTime: Date, // TODO: Next breaking change to update to optional or 'Date | undefined'?
     forceAsync: boolean,
     ...tags: string[]
   ) {

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -149,6 +149,7 @@ export class MetricsListener {
         if (this.currentProcessor === undefined) {
           this.currentProcessor = this.createProcessor(this.config, this.apiKey);
         }
+        // tslint:disable-next-line: no-floating-promises
         this.currentProcessor.then((processor) => {
           processor.addMetric(dist);
         });

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -135,8 +135,6 @@ export class MetricsListener {
     forceAsync: boolean,
     ...tags: string[]
   ) {
-    const dist = new Distribution(name, [{ timestamp: metricTime, value }], ...tags);
-
     if (this.isExtensionRunning) {
       const isMetricTimeValid = Date.parse(metricTime.toString()) > 0;
       if (isMetricTimeValid) {
@@ -152,6 +150,8 @@ export class MetricsListener {
       writeMetricToStdout(name, value, metricTime, tags);
       return;
     }
+
+    const dist = new Distribution(name, [{ timestamp: metricTime, value }], ...tags);
 
     if (!this.apiKey) {
       const errorMessage = "api key not configured, see https://dtdg.co/sls-node-metrics";
@@ -175,7 +175,7 @@ export class MetricsListener {
   }
 
   private async createProcessor(config: MetricsConfig, apiKey: Promise<string>) {
-    if (!this.isExtensionRunning && !this.config.logForwarding) {
+    if (!this.config.logForwarding) {
       const { APIClient } = require("./api");
       const { Processor } = require("./processor");
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Allows `sendDistributionMetricWithDate` to submit a metric with a timestamp when the Extension is running. Neither hot-shots nor Dogstatsd supports historical distribution metrics (more on the latter [here](https://github.com/Datadog/architecture/blob/master/rfcs/dogstatsd-no-aggregation-pipeline/rfc.md) and [here](https://datadoghq.atlassian.net/browse/FRMETS-1843)).

The ability to send metrics with timestamps already existed but did not work when using the Extension.

### Motivation

<!--- What inspired you to submit this pull request? --->
* [SVLS-4422](https://datadoghq.atlassian.net/browse/SVLS-4422)
* Related to: 
  * **TODO**: https://github.com/DataDog/datadog-lambda-python/issues/398 
  * https://github.com/DataDog/datadog-lambda-js/issues/58 

### Testing Guidelines

<!--- How did you test this pull request? --->
Unit test + manual tests. Example of one invocation using the following:
```js
const MS_PER_MINUTE = 60000;
const timestamp = new Date(Date.now() - MS_PER_MINUTE);
sendDistributionMetricWithDate("dylan.test.past", 1, timestamp);
sendDistributionMetric("dylan.test.present", 1); // tracer.dogstatsd.distribution("dylan.test.present", 1) also works
```
![Screenshot 2024-03-20 at 12 34 36 PM](https://github.com/DataDog/datadog-lambda-js/assets/25290232/3098c7a7-4ac4-4af0-8fee-242f858d9479)


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)


[SVLS-4422]: https://datadoghq.atlassian.net/browse/SVLS-4422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ