### PR TITLE
feat: support sending metrics before handler initialization

### DIFF
--- a/integration_tests/send-metrics.js
+++ b/integration_tests/send-metrics.js
@@ -1,5 +1,12 @@
 const { datadog, sendDistributionMetric } = require("datadog-lambda-js");
 
+sendDistributionMetric(
+  "serverless.integration_test.outside_handler",
+  1,
+  "tagkey:tagvalue",
+  `eventsource:outside_handler`,
+);
+
 async function handle(event, context) {
   const responsePayload = { message: "hello, dog!" };
 

--- a/integration_tests/snapshots/logs/async-metrics_node16.log
+++ b/integration_tests/snapshots/logs/async-metrics_node16.log
@@ -17,6 +17,17 @@ START
 }
 {
   "e": XXXX,
+  "m": "serverless.integration_test.outside_handler",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:outside_handler",
+    "dd_lambda_layer:datadog-nodev16.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGateway request
+{
+  "e": XXXX,
   "m": "serverless.integration_test.execution",
   "t": [
     "tagkey:tagvalue",
@@ -25,7 +36,6 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGateway request
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 START
 {
@@ -43,6 +53,7 @@ START
   ],
   "v": 1
 }
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS request
 {
   "e": XXXX,
   "m": "serverless.integration_test.records_processed",
@@ -63,9 +74,9 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS request
 END Duration: XXXX ms Memory Used: XXXX MB
 START
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS request
 {
   "e": XXXX,
   "m": "aws.lambda.enhanced.invocations",
@@ -111,5 +122,4 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS request
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_node18.log
+++ b/integration_tests/snapshots/logs/async-metrics_node18.log
@@ -17,6 +17,17 @@ START
 }
 {
   "e": XXXX,
+  "m": "serverless.integration_test.outside_handler",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:outside_handler",
+    "dd_lambda_layer:datadog-nodev18.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGateway request
+{
+  "e": XXXX,
   "m": "serverless.integration_test.execution",
   "t": [
     "tagkey:tagvalue",
@@ -25,7 +36,6 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGateway request
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 START
 {
@@ -43,6 +53,7 @@ START
   ],
   "v": 1
 }
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS request
 {
   "e": XXXX,
   "m": "serverless.integration_test.records_processed",
@@ -63,7 +74,6 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS request
 END Duration: XXXX ms Memory Used: XXXX MB
 START
 {
@@ -81,6 +91,7 @@ START
   ],
   "v": 1
 }
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS request
 {
   "e": XXXX,
   "m": "serverless.integration_test.records_processed",
@@ -111,5 +122,4 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS request
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/async-metrics_node20.log
+++ b/integration_tests/snapshots/logs/async-metrics_node20.log
@@ -15,7 +15,16 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGateway request
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.outside_handler",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:outside_handler",
+    "dd_lambda_layer:datadog-nodev20.XX.X"
+  ],
+  "v": 1
+}
 {
   "e": XXXX,
   "m": "serverless.integration_test.execution",
@@ -26,8 +35,10 @@ XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGat
   ],
   "v": 1
 }
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed APIGateway request
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 START
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS request
 {
   "e": XXXX,
   "m": "aws.lambda.enhanced.invocations",
@@ -43,7 +54,6 @@ START
   ],
   "v": 1
 }
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS request
 {
   "e": XXXX,
   "m": "serverless.integration_test.records_processed",
@@ -66,7 +76,6 @@ XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SNS re
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
-XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS request
 {
   "e": XXXX,
   "m": "aws.lambda.enhanced.invocations",
@@ -82,6 +91,7 @@ XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS re
   ],
   "v": 1
 }
+XXXX-XX-XX XX:XX:XX.XXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Processed SQS request
 {
   "e": XXXX,
   "m": "serverless.integration_test.records_processed",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -11,7 +11,6 @@ import { DatadogTraceHeaders } from "./trace/context/extractor";
 import { SpanContextWrapper } from "./trace/span-context-wrapper";
 import { TraceSource } from "./trace/trace-context-service";
 import { inflateSync } from "zlib";
-import { MetricsQueue } from "./metrics/queue";
 
 jest.mock("./metrics/enhanced-metrics");
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,7 +2,13 @@ import http from "http";
 import nock from "nock";
 
 import { Context, Handler } from "aws-lambda";
-import { datadog, getTraceHeaders, sendDistributionMetric, sendDistributionMetricWithDate, _metricsQueue } from "./index";
+import {
+  datadog,
+  getTraceHeaders,
+  sendDistributionMetric,
+  sendDistributionMetricWithDate,
+  _metricsQueue,
+} from "./index";
 import { incrementErrorsMetric, incrementInvocationsMetric } from "./metrics/enhanced-metrics";
 import { LogLevel, setLogLevel } from "./utils";
 import { HANDLER_STREAMING, STREAM_RESPONSE } from "./constants";
@@ -407,7 +413,7 @@ describe("datadog", () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
-      warn: jest.fn()
+      warn: jest.fn(),
     };
 
     const wrapped = datadog(handler, { forceWrap: true, logger: logger, debugLogging: true });
@@ -442,25 +448,24 @@ describe("datadog", () => {
   });
 });
 
-
 describe("sendDistributionMetric", () => {
   beforeEach(() => {
-    _metricsQueue.reset()
+    _metricsQueue.reset();
     setLogLevel(LogLevel.NONE);
-  })
+  });
   it("enqueues a metric for later processing when metrics listener is not initialized", () => {
     sendDistributionMetric("metric", 1, "first-tag", "second-tag");
-    expect(_metricsQueue.length).toBe(1); 
-  })
-})
+    expect(_metricsQueue.length).toBe(1);
+  });
+});
 
 describe("sendDistributionMetricWithDate", () => {
   beforeEach(() => {
-    _metricsQueue.reset()
+    _metricsQueue.reset();
     setLogLevel(LogLevel.NONE);
-  })
+  });
   it("enqueues a metric for later processing when metrics listener is not initialized", () => {
     sendDistributionMetricWithDate("metric", 1, new Date(), "first-tag", "second-tag");
-    expect(_metricsQueue.length).toBe(1); 
-  })
-})
+    expect(_metricsQueue.length).toBe(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,8 +279,12 @@ export function sendDistributionMetric(name: string, value: number, ...tags: str
 }
 
 function sendQueueMetrics(listener: MetricsListener) {
+  // Reverse the queue to send metrics in order.
+  // This is necessary because the "queue" is a stack,
+  // and we want to send metrics in the order they were added.
+  _metricsQueue.reverse();
   while (_metricsQueue.length > 0) {
-    const metric = _metricsQueue.shift()!; // This will always exist.
+    const metric = _metricsQueue.pop()!; // This will always exist.
     const { name, value, metricTime, tags } = metric;
     if (metricTime !== undefined) {
       listener.sendDistributionMetricWithDate(name, value, metricTime, false, ...tags);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import { TraceConfig, TraceListener } from "./trace";
 import { subscribeToDC } from "./runtime";
 import {
   logDebug,
-  logError,
   Logger,
   LogLevel,
   promisifiedHandler,

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ function sendQueueMetrics(listener: MetricsListener) {
     const { name, value, metricTime, tags } = metric;
     if (metricTime !== undefined) {
       listener.sendDistributionMetricWithDate(name, value, metricTime, false, ...tags);
-      return;
+      continue;
     }
 
     listener.sendDistributionMetric(name, value, false, ...tags);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,15 +10,7 @@ import {
 } from "./metrics";
 import { TraceConfig, TraceListener } from "./trace";
 import { subscribeToDC } from "./runtime";
-import {
-  logDebug,
-  Logger,
-  LogLevel,
-  promisifiedHandler,
-  setSandboxInit,
-  setLogger,
-  setLogLevel,
-} from "./utils";
+import { logDebug, Logger, LogLevel, promisifiedHandler, setSandboxInit, setLogger, setLogLevel } from "./utils";
 import { getEnhancedMetricTags } from "./metrics/enhanced-metrics";
 import { DatadogTraceHeaders } from "./trace/context/extractor";
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,3 +1,4 @@
 export { MetricsConfig, MetricsListener } from "./listener";
+export { MetricsQueue } from './queue'
 export { KMSService } from "./kms-service";
 export { incrementErrorsMetric, incrementInvocationsMetric } from "./enhanced-metrics";

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,4 +1,4 @@
 export { MetricsConfig, MetricsListener } from "./listener";
-export { MetricsQueue } from './queue'
+export { MetricsQueue } from "./queue";
 export { KMSService } from "./kms-service";
 export { incrementErrorsMetric, incrementInvocationsMetric } from "./enhanced-metrics";

--- a/src/metrics/queue.spec.ts
+++ b/src/metrics/queue.spec.ts
@@ -1,0 +1,65 @@
+import { LogLevel, logDebug, setLogLevel, setLogger } from "../utils";
+import { METRICS_QUEUE_LIMIT, MetricsQueue } from "./queue";
+
+describe("MetricsQueue", () => {
+  const logger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn()
+  };
+  describe("push", () => {
+    beforeEach(() => {
+      setLogLevel(LogLevel.NONE);
+      setLogger(logger);
+    })
+    it("resets metrics queue when its full", () => {
+      setLogLevel(LogLevel.WARNING);
+      const queue = new MetricsQueue();
+      for (let i = 0; i < METRICS_QUEUE_LIMIT + 1; i++) {
+        queue.push({ name: "metric", tags: [], value: i });
+      }
+
+      // The queue should have been reset and only contain the last metric
+      expect(queue.length).toBe(1)
+      expect(logger.warn).toHaveBeenLastCalledWith('{"status":"warning","message":"datadog:Metrics queue is full, dropping all metrics."}');
+    })
+
+    it("enqueue metric", () => {
+      setLogLevel(LogLevel.DEBUG);
+      const queue = new MetricsQueue();
+      queue.push({ name: "metric", tags: [], value: 1 });
+      expect(queue.length).toBe(1)
+      expect(logger.debug).toHaveBeenLastCalledWith('{"status":"debug","message":"datadog:Metrics Listener was not initialized. Enqueuing metric for later processing."}');
+    })
+    
+  });
+
+  describe("shift", () => {
+    it("returns undefined when queue is empty", () => {
+      const queue = new MetricsQueue();
+      expect(queue.shift()).toBeUndefined();
+    });
+
+    it("returns the first element in the queue", () => {
+      const queue = new MetricsQueue();
+      queue.push({ name: "metric", tags: [], value: 1 });
+      queue.push({ name: "metric", tags: [], value: 2 });
+      expect(queue.shift()).toEqual({ name: "metric", tags: [], value: 1 });
+    });
+  });
+
+  it("resets the queue", () => { 
+    const queue = new MetricsQueue();
+    queue.push({ name: "metric", tags: [], value: 1 });
+    queue.push({ name: "metric", tags: [], value: 2 });
+    queue.reset();
+    expect(queue.length).toBe(0);
+  });
+
+  it("returns the length of the queue", () => {
+    const queue = new MetricsQueue();
+    queue.push({ name: "metric", tags: [], value: 1 });
+    queue.push({ name: "metric", tags: [], value: 2 });
+    expect(queue.length).toBe(2);
+  });
+})

--- a/src/metrics/queue.spec.ts
+++ b/src/metrics/queue.spec.ts
@@ -5,13 +5,13 @@ describe("MetricsQueue", () => {
   const logger = {
     debug: jest.fn(),
     error: jest.fn(),
-    warn: jest.fn()
+    warn: jest.fn(),
   };
   describe("push", () => {
     beforeEach(() => {
       setLogLevel(LogLevel.NONE);
       setLogger(logger);
-    })
+    });
     it("resets metrics queue when its full", () => {
       setLogLevel(LogLevel.WARNING);
       const queue = new MetricsQueue();
@@ -20,18 +20,21 @@ describe("MetricsQueue", () => {
       }
 
       // The queue should have been reset and only contain the last metric
-      expect(queue.length).toBe(1)
-      expect(logger.warn).toHaveBeenLastCalledWith('{"status":"warning","message":"datadog:Metrics queue is full, dropping all metrics."}');
-    })
+      expect(queue.length).toBe(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        '{"status":"warning","message":"datadog:Metrics queue is full, dropping all metrics."}',
+      );
+    });
 
     it("enqueue metric", () => {
       setLogLevel(LogLevel.DEBUG);
       const queue = new MetricsQueue();
       queue.push({ name: "metric", tags: [], value: 1 });
-      expect(queue.length).toBe(1)
-      expect(logger.debug).toHaveBeenLastCalledWith('{"status":"debug","message":"datadog:Metrics Listener was not initialized. Enqueuing metric for later processing."}');
-    })
-    
+      expect(queue.length).toBe(1);
+      expect(logger.debug).toHaveBeenLastCalledWith(
+        '{"status":"debug","message":"datadog:Metrics Listener was not initialized. Enqueuing metric for later processing."}',
+      );
+    });
   });
 
   describe("shift", () => {
@@ -48,7 +51,7 @@ describe("MetricsQueue", () => {
     });
   });
 
-  it("resets the queue", () => { 
+  it("resets the queue", () => {
     const queue = new MetricsQueue();
     queue.push({ name: "metric", tags: [], value: 1 });
     queue.push({ name: "metric", tags: [], value: 2 });
@@ -62,4 +65,4 @@ describe("MetricsQueue", () => {
     queue.push({ name: "metric", tags: [], value: 2 });
     expect(queue.length).toBe(2);
   });
-})
+});

--- a/src/metrics/queue.spec.ts
+++ b/src/metrics/queue.spec.ts
@@ -37,18 +37,26 @@ describe("MetricsQueue", () => {
     });
   });
 
-  describe("shift", () => {
+  describe("pop", () => {
     it("returns undefined when queue is empty", () => {
       const queue = new MetricsQueue();
-      expect(queue.shift()).toBeUndefined();
+      expect(queue.pop()).toBeUndefined();
     });
 
     it("returns the first element in the queue", () => {
       const queue = new MetricsQueue();
       queue.push({ name: "metric", tags: [], value: 1 });
       queue.push({ name: "metric", tags: [], value: 2 });
-      expect(queue.shift()).toEqual({ name: "metric", tags: [], value: 1 });
+      expect(queue.pop()).toEqual({ name: "metric", tags: [], value: 2 });
     });
+  });
+
+  it("reverses the queue", () => {
+    const queue = new MetricsQueue();
+    queue.push({ name: "metric", tags: [], value: 1 });
+    queue.push({ name: "metric", tags: [], value: 2 });
+    queue.reverse();
+    expect(queue.pop()).toEqual({ name: "metric", tags: [], value: 1 });
   });
 
   it("resets the queue", () => {

--- a/src/metrics/queue.ts
+++ b/src/metrics/queue.ts
@@ -36,12 +36,16 @@ export class MetricsQueue {
     this.queue.push(metric);
   }
 
-  public shift() {
+  public pop() {
     if (this.queue.length > 0) {
-      return this.queue.shift();
+      return this.queue.pop();
     }
 
     return undefined;
+  }
+
+  public reverse() {
+    this.queue.reverse();
   }
 
   public reset() {

--- a/src/metrics/queue.ts
+++ b/src/metrics/queue.ts
@@ -1,0 +1,54 @@
+import { logDebug, logWarning } from "../utils";
+
+export type MetricParameters = {
+  value: number;
+  name: string;
+  tags: string[];
+  metricTime?: Date;
+};
+
+export const METRICS_QUEUE_LIMIT = 1024;
+
+/**
+ * MetricsQueue is a queue for metrics that are enqueued when the MetricsListener is not initialized.
+ *
+ * When the MetricsListener is initialized, the metrics are sent to the listener for processing.
+ * If the queue is full, all metrics are dropped, and new ones are enqueued. This might happen in two
+ * scenarios:
+ * 1. The MetricsListener is not initialized for a long time.
+ * 2. The MetricsListener is initialized, but the amount of enqueued metrics is higher than the limit.
+ */
+export class MetricsQueue {
+  private queue: MetricParameters[] = [];
+
+  /**
+   * Enqueues a metric for later processing.
+   * If the queue is full, all metrics are dropped. But the new metric is still enqueued.
+   * 
+   * @param metric The metric to be enqueued.
+   */
+  public push(metric: MetricParameters) {
+    logDebug("Metrics Listener was not initialized. Enqueuing metric for later processing.");
+    if (this.queue.length >= METRICS_QUEUE_LIMIT) {
+      logWarning("Metrics queue is full, dropping all metrics.");
+      this.reset();
+    }
+    this.queue.push(metric);
+  }
+
+  public shift() {
+    if (this.queue.length > 0) {
+      return this.queue.shift();
+    }
+
+    return undefined;
+  }
+
+  public reset() {
+    this.queue = [];
+  }
+
+  public get length() {
+    return this.queue.length;
+  }
+}

--- a/src/metrics/queue.ts
+++ b/src/metrics/queue.ts
@@ -24,7 +24,7 @@ export class MetricsQueue {
   /**
    * Enqueues a metric for later processing.
    * If the queue is full, all metrics are dropped. But the new metric is still enqueued.
-   * 
+   *
    * @param metric The metric to be enqueued.
    */
   public push(metric: MetricParameters) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { didFunctionColdStart, getSandboxInitTags, setSandboxInit, isProactiveInitialization } from "./cold-start";
 export { wrap, promisifiedHandler } from "./handler";
 export { Timer } from "./timer";
-export { logError, logDebug, Logger, setLogLevel, setLogger, LogLevel } from "./log";
+export { logWarning, logError, logDebug, Logger, setLogLevel, setLogger, LogLevel } from "./log";
 export { tagObject } from "./tag-object";

--- a/src/utils/log.spec.ts
+++ b/src/utils/log.spec.ts
@@ -1,10 +1,11 @@
-import { setLogger, logError } from "./log";
+import { setLogger, logError, logDebug, logWarning } from "./log";
 
 describe("logger", () => {
   it("log using custom logger", async () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
+      warn: jest.fn()
     };
 
     setLogger(logger);
@@ -12,10 +13,12 @@ describe("logger", () => {
 
     expect(logger.error).toHaveBeenLastCalledWith('{"status":"error","message":"datadog:My Error"}');
   });
+
   it("logs errors correctly", async () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
+      warn: jest.fn()
     };
 
     setLogger(logger);
@@ -23,10 +26,12 @@ describe("logger", () => {
     const lastErrorCall = logger.error.mock.calls[0][0];
     expect(lastErrorCall).toContain('{"status":"error","message":"Oh no!","name":"Error","stack":"Error: Oh no!');
   });
+
   it("logs errors and metadata correctly", async () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
+      warn: jest.fn()
     };
 
     setLogger(logger);
@@ -36,5 +41,18 @@ describe("logger", () => {
     expect(lastErrorCall).toContain(
       '{"status":"error","message":"Oh no 2!","foo":"bar","baz":"2","name":"Error","stack":"Error: Oh no 2!',
     );
+  });
+
+  it("logs warnings correctly", async () => {
+    const logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn()
+    };
+
+    setLogger(logger);
+    logWarning("This is a warning");
+    const lastWarning = logger.warn.mock.calls[0][0];
+    expect(lastWarning).toContain('{"status":"warning","message":"datadog:This is a warning"}');
   });
 });

--- a/src/utils/log.spec.ts
+++ b/src/utils/log.spec.ts
@@ -5,7 +5,7 @@ describe("logger", () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
-      warn: jest.fn()
+      warn: jest.fn(),
     };
 
     setLogger(logger);
@@ -18,7 +18,7 @@ describe("logger", () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
-      warn: jest.fn()
+      warn: jest.fn(),
     };
 
     setLogger(logger);
@@ -31,7 +31,7 @@ describe("logger", () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
-      warn: jest.fn()
+      warn: jest.fn(),
     };
 
     setLogger(logger);
@@ -47,7 +47,7 @@ describe("logger", () => {
     const logger = {
       debug: jest.fn(),
       error: jest.fn(),
-      warn: jest.fn()
+      warn: jest.fn(),
     };
 
     setLogger(logger);

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -3,12 +3,14 @@ import { serializeError } from "serialize-error";
 export enum LogLevel {
   DEBUG = 0,
   ERROR,
+  WARNING,
   NONE,
 }
 
 export interface Logger {
   debug(message: string): void;
   error(message: string): void;
+  warn(message: string): void;
 }
 
 let logger: Logger = console;
@@ -38,6 +40,13 @@ export function logError(message: string, metadata?: Error | object, error?: Err
     return;
   }
   emitLog(logger.error, "error", message, metadata, error);
+}
+
+export function logWarning(message: string, metadata?: Error | object, error?: Error) {
+  if (logLevel > LogLevel.WARNING) {
+    return;
+  }
+  emitLog(logger.warn, "warning", message, metadata, error);
 }
 
 function emitLog(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allows customer to use the API `sendDistributionMetric` and `sendDistributionMetricWithDate` outside of the handler.

### Motivation

#515 

### Testing Guidelines

- Added unit tests
- Added integration test
- Tested manually

### Additional Notes

[SVLS-4633](https://datadoghq.atlassian.net/browse/SVLS-4633)

### Types of Changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)


[SVLS-4633]: https://datadoghq.atlassian.net/browse/SVLS-4633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ