### PR TITLE
trace: tag http.route on api-gateway spans

### DIFF
--- a/src/trace/trigger.ts
+++ b/src/trace/trigger.ts
@@ -141,7 +141,7 @@ export function parseEventSource(event: any) {
     return eventTypes.lambdaUrl;
   }
   if (
-    eventType.isAPIGatewayEvent(event) ||
+    eventType.(event) ||
     eventType.isAPIGatewayEventV2(event) ||
     eventType.isAPIGatewayWebsocketEvent(event)
   ) {
@@ -272,6 +272,7 @@ function extractHTTPTags(event: APIGatewayEvent | APIGatewayProxyEventV2 | ALBEv
     }
     httpTags["http.url_details.path"] = requestContext.path;
     httpTags["http.method"] = requestContext.httpMethod;
+    httpTags["http.route"] = event.resource;
     if (event.headers?.Referer) {
       httpTags["http.referer"] = event.headers.Referer;
     }
@@ -283,6 +284,7 @@ function extractHTTPTags(event: APIGatewayEvent | APIGatewayProxyEventV2 | ALBEv
     httpTags["http.url"] = requestContext.domainName;
     httpTags["http.url_details.path"] = requestContext.http.path;
     httpTags["http.method"] = requestContext.http.method;
+    httpTags["http.route"] = event.resource;
     if (event.headers?.Referer) {
       httpTags["http.referer"] = event.headers.Referer;
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Add the missing http.route span tag to api gateway spans.

### Motivation

<!--- What inspired you to submit this pull request? --->
Support the APM's API Catalog which needs this span tag to list their entries in the API Catalog.

### Testing Guidelines

<!--- How did you test this pull request? --->
TODO

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
