### PR TITLE
Capture and handle errors during stringify.

### DIFF
--- a/src/utils/tag-object.spec.ts
+++ b/src/utils/tag-object.spec.ts
@@ -99,6 +99,23 @@ describe("tagObject", () => {
       ["function.request.vals.1", '{"thingTwo":2}'],
     ]);
   });
+  it("handles circular objects", () => {
+    const span = {
+      setTag,
+    };
+    var obj = {
+      key: "value",
+      array: Array<any>(),
+    };
+    obj.array.push(obj);
+    tagObject(span, "lambda_payload", { request: obj }, 1);
+    expect(setTag.mock.calls).toEqual([
+      ["lambda_payload.request.key", "value"],
+      ["lambda_payload.request.array.0.key", "value"],
+      ["lambda_payload.request.array.0.array.0.key", "value"],
+      ["lambda_payload.request.array.0.array.0.array.0.key", "value"],
+    ]);
+  });
   it("redacts common secret keys", () => {
     const span = {
       setTag,

--- a/src/utils/tag-object.ts
+++ b/src/utils/tag-object.ts
@@ -1,3 +1,5 @@
+import { logDebug } from "./log";
+
 const redactableKeys = ["authorization", "x-authorization", "password", "token"];
 
 export function tagObject(currentSpan: any, key: string, obj: any, depth = 0, maxDepth = 10): any {
@@ -6,7 +8,13 @@ export function tagObject(currentSpan: any, key: string, obj: any, depth = 0, ma
     return currentSpan.setTag(key, obj);
   }
   if (depth >= maxDepth) {
-    const strOrUndefined = JSON.stringify(obj);
+    let strOrUndefined;
+    try {
+      strOrUndefined = JSON.stringify(obj);
+    } catch (e) {
+      logDebug(`Unable to stringify object for tagging: ${e}`);
+      return;
+    }
     if (typeof strOrUndefined === "undefined") return;
     return currentSpan.setTag(key, redactVal(key, strOrUndefined.substring(0, 5000)));
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
When the response object contains a circular reference, `JSON.stringify` will throw an error. This should be caught and ignored.

### Motivation

<!--- What inspired you to submit this pull request? --->
Fixes https://github.com/DataDog/datadog-lambda-js/issues/541

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
