### PR TITLE
Step Functions Legacy Lambda Span Linking

### DIFF
--- a/src/trace/context/extractor.spec.ts
+++ b/src/trace/context/extractor.spec.ts
@@ -917,7 +917,8 @@ describe("TraceContextExtractor", () => {
               MyInput: "MyValue",
             },
             Name: "85a9933e-9e11-83dc-6a61-b92367b6c3be",
-            RoleArn: "arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03",
+            RoleArn:
+              "arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03",
             StartTime: "2022-12-08T21:08:17.924Z",
           },
           State: {
@@ -929,7 +930,7 @@ describe("TraceContextExtractor", () => {
             Id: "arn:aws:states:sa-east-1:425362996713:stateMachine:logs-to-traces-sequential",
             Name: "my-state-machine",
           },
-        }
+        },
       };
 
       const tracerWrapper = new TracerWrapper();

--- a/src/trace/context/extractor.spec.ts
+++ b/src/trace/context/extractor.spec.ts
@@ -907,6 +907,42 @@ describe("TraceContextExtractor", () => {
 
       expect(extractor).toBeInstanceOf(StepFunctionEventTraceExtractor);
     });
+
+    it("returns StepFunctionEventTraceExtractor when event contains legacy lambda StepFunctionContext", () => {
+      const event = {
+        Payload: {
+          Execution: {
+            Id: "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf",
+            Input: {
+              MyInput: "MyValue",
+            },
+            Name: "85a9933e-9e11-83dc-6a61-b92367b6c3be",
+            RoleArn: "arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03",
+            StartTime: "2022-12-08T21:08:17.924Z",
+          },
+          State: {
+            Name: "step-one",
+            EnteredTime: "2022-12-08T21:08:19.224Z",
+            RetryCount: 2,
+          },
+          StateMachine: {
+            Id: "arn:aws:states:sa-east-1:425362996713:stateMachine:logs-to-traces-sequential",
+            Name: "my-state-machine",
+          },
+        }
+      };
+
+      const tracerWrapper = new TracerWrapper();
+      const traceContextExtractor = new TraceContextExtractor(tracerWrapper, {} as TraceConfig);
+
+      // Mimick TraceContextService.extract initialization
+      const instance = StepFunctionContextService.instance(event);
+      traceContextExtractor["stepFunctionContextService"] = instance;
+
+      const extractor = traceContextExtractor["getTraceEventExtractor"](event);
+
+      expect(extractor).toBeInstanceOf(StepFunctionEventTraceExtractor);
+    });
   });
 
   describe("addTraceContexToXray", () => {

--- a/src/trace/context/extractors/step-function.spec.ts
+++ b/src/trace/context/extractors/step-function.spec.ts
@@ -55,6 +55,22 @@ describe("StepFunctionEventTraceExtractor", () => {
       expect(traceContext?.source).toBe("event");
     });
 
+    it("extracts trace context with valid legacy lambda payload", () => {
+      // Mimick TraceContextService.extract initialization
+      StepFunctionContextService.instance({ Payload: payload });
+
+      const extractor = new StepFunctionEventTraceExtractor();
+
+      // Payload is sent again for safety in case the instance wasn't previously initialized
+      const traceContext = extractor.extract({ Payload: payload });
+      expect(traceContext).not.toBeNull();
+
+      expect(traceContext?.toTraceId()).toBe("1139193989631387307");
+      expect(traceContext?.toSpanId()).toBe("5892738536804826142");
+      expect(traceContext?.sampleMode()).toBe("1");
+      expect(traceContext?.source).toBe("event");
+    });
+
     it("returns null when StepFunctionContextService.context is undefined", async () => {
       const extractor = new StepFunctionEventTraceExtractor();
 

--- a/src/trace/step-function-service.spec.ts
+++ b/src/trace/step-function-service.spec.ts
@@ -213,7 +213,7 @@ describe("StepFunctionContextService", () => {
     it("returns a SpanContextWrapper when event is from legacy lambda", () => {
       const instance = StepFunctionContextService.instance();
       // Force setting event
-      instance["setContext"]({"Payload": stepFunctionEvent});
+      instance["setContext"]({ Payload: stepFunctionEvent });
 
       const spanContext = instance.spanContext;
 

--- a/src/trace/step-function-service.spec.ts
+++ b/src/trace/step-function-service.spec.ts
@@ -209,6 +209,21 @@ describe("StepFunctionContextService", () => {
 
       expect(spanContext).toBeNull();
     });
+
+    it("returns a SpanContextWrapper when event is from legacy lambda", () => {
+      const instance = StepFunctionContextService.instance();
+      // Force setting event
+      instance["setContext"]({"Payload": stepFunctionEvent});
+
+      const spanContext = instance.spanContext;
+
+      expect(spanContext).not.toBeNull();
+
+      expect(spanContext?.toTraceId()).toBe("1139193989631387307");
+      expect(spanContext?.toSpanId()).toBe("5892738536804826142");
+      expect(spanContext?.sampleMode()).toBe("1");
+      expect(spanContext?.source).toBe("event");
+    });
   });
 
   describe("deterministicSha256HashToBigIntString", () => {

--- a/src/trace/step-function-service.ts
+++ b/src/trace/step-function-service.ts
@@ -41,6 +41,12 @@ export class StepFunctionContextService {
     // always triggered by the same event.
     if (typeof event !== "object") return;
 
+    // Legacy lambda parsing
+    const payload = event.Payload;
+    if (typeof payload === "object") {
+      event = payload;
+    }
+
     // Execution
     const execution = event.Execution;
     if (typeof execution !== "object") {
@@ -130,10 +136,10 @@ export class StepFunctionContextService {
     const traceId = this.deterministicSha256HashToBigIntString(this.context["step_function.execution_id"], TRACE_ID);
     const parentId = this.deterministicSha256HashToBigIntString(
       this.context["step_function.execution_id"] +
-        "#" +
-        this.context["step_function.state_name"] +
-        "#" +
-        this.context["step_function.state_entered_time"],
+      "#" +
+      this.context["step_function.state_name"] +
+      "#" +
+      this.context["step_function.state_entered_time"],
       PARENT_ID,
     );
     const sampleMode = SampleMode.AUTO_KEEP;

--- a/src/trace/step-function-service.ts
+++ b/src/trace/step-function-service.ts
@@ -42,9 +42,8 @@ export class StepFunctionContextService {
     if (typeof event !== "object") return;
 
     // Legacy lambda parsing
-    const payload = event.Payload;
-    if (typeof payload === "object") {
-      event = payload;
+    if (typeof event.Payload === "object") {
+      event = event.Payload;
     }
 
     // Execution

--- a/src/trace/step-function-service.ts
+++ b/src/trace/step-function-service.ts
@@ -136,10 +136,10 @@ export class StepFunctionContextService {
     const traceId = this.deterministicSha256HashToBigIntString(this.context["step_function.execution_id"], TRACE_ID);
     const parentId = this.deterministicSha256HashToBigIntString(
       this.context["step_function.execution_id"] +
-      "#" +
-      this.context["step_function.state_name"] +
-      "#" +
-      this.context["step_function.state_entered_time"],
+        "#" +
+        this.context["step_function.state_name"] +
+        "#" +
+        this.context["step_function.state_entered_time"],
       PARENT_ID,
     );
     const sampleMode = SampleMode.AUTO_KEEP;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Step Function events that are from Legacy Lambda enter the layer wrapped in a `Payload: {}`. Here's an example
```
{'Payload': {'Execution': {'Id': 'arn:aws:states:sa-east-1:425362996713:execution:abhinav-legacy-lam-sf:ca7383bc-e370-4a85-a266-a4686bd7d00f', 'Input': {}, 'StartTime': '2024-08-08T18:55:03.805Z', 'Name': 'ca7383bc-e370-4a85-a266-a4686bd7d00f', 'RoleArn': 'arn:aws:iam::425362996713:role/service-role/StepFunctions-abhinav-test-1-role-4u48d0717', 'RedriveCount': 0}, 'StateMachine': {'Id': 'arn:aws:states:sa-east-1:425362996713:stateMachine:abhinav-legacy-lam-sf', 'Name': 'abhinav-legacy-lam-sf'}, 'State': {'Name': 'Lambda Invoke', 'EnteredTime': '2024-08-08T18:55:03.847Z', 'RetryCount': 0}}}
```

This change will check if events fall into this case and parse them accordingly so that we can extract the trace context and infer a span link between the Step Function and the downstream Legacy Lambda

### Motivation

https://github.com/DataDog/logs-backend/pull/78707

### Testing Guidelines

* [Link](https://dd.datad0g.com/apm/trace/7012f61eb96fd16749145c6d10eaa1be?colorBy=service&env=dev&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=1117413845479212096&spanViewType=metadata&timeHint=1723224455138&view=spans) to a Step Functions trace with a linked lambda span using this version of the js layer
* Added unit test cases with legacy lambda payload

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
