### PR TITLE
Step Functions Trace Merging Support

### DIFF
--- a/event_samples/states.json
+++ b/event_samples/states.json
@@ -1,0 +1,22 @@
+{
+    "_datadog": {
+      "Execution": {
+        "Id": "arn:aws:states:ca-central-1:425362996713:execution:MyStateMachine-wsx8chv4d:1356a963-42a5-48b0-ba3f-73bde559a50c",
+        "StartTime": "2024-11-13T16:46:47.715Z",
+        "Name": "1356a963-42a5-48b0-ba3f-73bde559a50c",
+        "RoleArn": "arn:aws:iam::425362996713:role/service-role/StepFunctions-MyStateMachine-wsx8chv4d-role-1su0fkfd3",
+        "RedriveCount": 0
+      },
+      "StateMachine": {
+        "Id": "arn:aws:states:ca-central-1:425362996713:stateMachine:MyStateMachine-wsx8chv4d",
+        "Name": "MyStateMachine-wsx8chv4d"
+      },
+      "State": {
+        "Name": "Lambda Invoke",
+        "EnteredTime": "2024-11-13T16:46:47.740Z",
+        "RetryCount": 0
+      },
+      "RootExecutionId": "arn:aws:states:ca-central-1:425362996713:execution:MyStateMachine-wsx8chv4d:1356a963-42a5-48b0-ba3f-73bde559a50c",
+      "serverless-version": "v1"
+    }
+  }

--- a/src/trace/context/extractor.spec.ts
+++ b/src/trace/context/extractor.spec.ts
@@ -874,8 +874,8 @@ describe("TraceContextExtractor", () => {
       expect(extractor).toBeInstanceOf(_class);
     });
 
-    it("returns StepFunctionEventTraceExtractor when event contains StepFunctionContext", () => {
-      const event = {
+    it("returns StepFunctionEventTraceExtractor when event contains LegacyStepFunctionContext", () => {
+      const legacyStepFunctionEvent = {
         Execution: {
           Id: "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf",
           Input: {
@@ -900,10 +900,90 @@ describe("TraceContextExtractor", () => {
       const traceContextExtractor = new TraceContextExtractor(tracerWrapper, {} as TraceConfig);
 
       // Mimick TraceContextService.extract initialization
-      const instance = StepFunctionContextService.instance(event);
+      const instance = StepFunctionContextService.instance(legacyStepFunctionEvent);
       traceContextExtractor["stepFunctionContextService"] = instance;
 
-      const extractor = traceContextExtractor["getTraceEventExtractor"](event);
+      const extractor = traceContextExtractor["getTraceEventExtractor"](legacyStepFunctionEvent);
+
+      expect(extractor).toBeInstanceOf(StepFunctionEventTraceExtractor);
+    });
+
+    it("returns StepFunctionEventTraceExtractor when event contains LambdaRootStepFunctionContext", () => {
+      const lambdaRootStepFunctionEvent = {
+        _datadog: {
+          Execution: {
+            Id: "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf",
+            Input: {
+              MyInput: "MyValue",
+            },
+            Name: "85a9933e-9e11-83dc-6a61-b92367b6c3be",
+            RoleArn:
+              "arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03",
+            StartTime: "2022-12-08T21:08:17.924Z",
+          },
+          State: {
+            Name: "step-one",
+            EnteredTime: "2022-12-08T21:08:19.224Z",
+            RetryCount: 2,
+          },
+          StateMachine: {
+            Id: "arn:aws:states:sa-east-1:425362996713:stateMachine:logs-to-traces-sequential",
+            Name: "my-state-machine",
+          },
+          "x-datadog-trace-id": "10593586103637578129",
+          "x-datadog-tags": "_dd.p.dm=-0,_dd.p.tid=6734e7c300000000",
+          "serverless-version": "v1",
+        },
+      };
+
+      const tracerWrapper = new TracerWrapper();
+      const traceContextExtractor = new TraceContextExtractor(tracerWrapper, {} as TraceConfig);
+
+      // Mimick TraceContextService.extract initialization
+      const instance = StepFunctionContextService.instance(lambdaRootStepFunctionEvent);
+      traceContextExtractor["stepFunctionContextService"] = instance;
+
+      const extractor = traceContextExtractor["getTraceEventExtractor"](lambdaRootStepFunctionEvent);
+
+      expect(extractor).toBeInstanceOf(StepFunctionEventTraceExtractor);
+    });
+
+    it("returns StepFunctionEventTraceExtractor when event contains NestedStepFunctionContext", () => {
+      const nestedStepFunctionEvent = {
+        _datadog: {
+          Execution: {
+            Id: "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf",
+            Input: {
+              MyInput: "MyValue",
+            },
+            Name: "85a9933e-9e11-83dc-6a61-b92367b6c3be",
+            RoleArn:
+              "arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03",
+            StartTime: "2022-12-08T21:08:17.924Z",
+          },
+          State: {
+            Name: "step-one",
+            EnteredTime: "2022-12-08T21:08:19.224Z",
+            RetryCount: 2,
+          },
+          StateMachine: {
+            Id: "arn:aws:states:sa-east-1:425362996713:stateMachine:logs-to-traces-sequential",
+            Name: "my-state-machine",
+          },
+          RootExecutionId:
+            "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:a1b2c3d4-e5f6-7890-1234-56789abcdef0:9f8e7d6c-5b4a-3c2d-1e0f-123456789abc",
+          "serverless-version": "v1",
+        },
+      };
+
+      const tracerWrapper = new TracerWrapper();
+      const traceContextExtractor = new TraceContextExtractor(tracerWrapper, {} as TraceConfig);
+
+      // Mimick TraceContextService.extract initialization
+      const instance = StepFunctionContextService.instance(nestedStepFunctionEvent);
+      traceContextExtractor["stepFunctionContextService"] = instance;
+
+      const extractor = traceContextExtractor["getTraceEventExtractor"](nestedStepFunctionEvent);
 
       expect(extractor).toBeInstanceOf(StepFunctionEventTraceExtractor);
     });

--- a/src/trace/context/extractor.spec.ts
+++ b/src/trace/context/extractor.spec.ts
@@ -946,7 +946,7 @@ describe("TraceContextExtractor", () => {
     });
   });
 
-  describe("addTraceContexToXray", () => {
+  describe("addTraceContextToXray", () => {
     beforeEach(() => {
       StepFunctionContextService["_instance"] = undefined as any;
       sentSegment = undefined;
@@ -955,7 +955,7 @@ describe("TraceContextExtractor", () => {
       process.env["AWS_XRAY_DAEMON_ADDRESS"] = undefined;
     });
 
-    it("adds StepFunction context when present over metadata", () => {
+    it("adds legacy StepFunction context when present over metadata", () => {
       jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
 
       process.env["_X_AMZN_TRACE_ID"] = "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1";
@@ -1006,7 +1006,7 @@ describe("TraceContextExtractor", () => {
 
       const sentMessage = sentSegment.toString();
       expect(sentMessage).toEqual(
-        '{"format": "json", "version": 1}\n{"id":"11111","trace_id":"1-5e272390-8c398be037738dc042009320","parent_id":"94ae789b969f1cc5","name":"datadog-metadata","start_time":1487076708,"end_time":1487076708,"type":"subsegment","metadata":{"datadog":{"root_span_metadata":{"step_function.execution_name":"85a9933e-9e11-83dc-6a61-b92367b6c3be","step_function.execution_id":"arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf","step_function.execution_input":{"MyInput":"MyValue"},"step_function.execution_role_arn":"arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03","step_function.execution_start_time":"2022-12-08T21:08:17.924Z","step_function.state_entered_time":"2022-12-08T21:08:19.224Z","step_function.state_machine_arn":"arn:aws:states:sa-east-1:425362996713:stateMachine:logs-to-traces-sequential","step_function.state_machine_name":"my-state-machine","step_function.state_name":"step-one","step_function.state_retry_count":2}}}}',
+        '{"format": "json", "version": 1}\n{"id":"11111","trace_id":"1-5e272390-8c398be037738dc042009320","parent_id":"94ae789b969f1cc5","name":"datadog-metadata","start_time":1487076708,"end_time":1487076708,"type":"subsegment","metadata":{"datadog":{"root_span_metadata":{"execution_id":"arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf","state_entered_time":"2022-12-08T21:08:19.224Z","state_name":"step-one"}}}}',
       );
     });
 

--- a/src/trace/step-function-service.spec.ts
+++ b/src/trace/step-function-service.spec.ts
@@ -1,7 +1,7 @@
 import { PARENT_ID, StepFunctionContextService } from "./step-function-service";
 
 describe("StepFunctionContextService", () => {
-  const stepFunctionEvent = {
+  const legacyStepFunctionEvent = {
     Execution: {
       Id: "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf",
       Input: {
@@ -40,75 +40,35 @@ describe("StepFunctionContextService", () => {
       ["event is not an object", "event"],
       ["event is missing Execution property", {}],
       [
-        "Execution is missing Name field",
+        "Execution is not defined",
         {
-          ...stepFunctionEvent,
-          Execution: {},
+          ...legacyStepFunctionEvent,
+          Execution: undefined,
         },
       ],
       [
         "Execution Id is not a string",
         {
-          ...stepFunctionEvent,
+          ...legacyStepFunctionEvent,
           Execution: {
-            ...stepFunctionEvent.Execution,
+            ...legacyStepFunctionEvent.Execution,
             Id: 1,
-          },
-        },
-      ],
-      [
-        "Execution Name isn't a string",
-        {
-          ...stepFunctionEvent,
-          Execution: {
-            ...stepFunctionEvent.Execution,
-            Name: 12345,
-          },
-        },
-      ],
-      [
-        "Execution RoleArn isn't a string",
-        {
-          ...stepFunctionEvent,
-          Execution: {
-            ...stepFunctionEvent.Execution,
-            RoleArn: 12345,
-          },
-        },
-      ],
-      [
-        "Execution StartTime isn't a string",
-        {
-          ...stepFunctionEvent,
-          Execution: {
-            ...stepFunctionEvent.Execution,
-            StartTime: 12345,
           },
         },
       ],
       [
         "State is not defined",
         {
-          ...stepFunctionEvent,
+          ...legacyStepFunctionEvent,
           State: undefined,
-        },
-      ],
-      [
-        "State RetryCount is not a number",
-        {
-          ...stepFunctionEvent,
-          State: {
-            ...stepFunctionEvent.State,
-            RetryCount: "1",
-          },
         },
       ],
       [
         "State EnteredTime is not a string",
         {
-          ...stepFunctionEvent,
+          ...legacyStepFunctionEvent,
           State: {
-            ...stepFunctionEvent.State,
+            ...legacyStepFunctionEvent.State,
             EnteredTime: 12345,
           },
         },
@@ -116,36 +76,9 @@ describe("StepFunctionContextService", () => {
       [
         "State Name is not a string",
         {
-          ...stepFunctionEvent,
+          ...legacyStepFunctionEvent,
           State: {
-            ...stepFunctionEvent,
-            Name: 1,
-          },
-        },
-      ],
-      [
-        "StateMachine is undefined",
-        {
-          ...stepFunctionEvent,
-          StateMachine: undefined,
-        },
-      ],
-      [
-        "StateMachine Id is not a string",
-        {
-          ...stepFunctionEvent,
-          StateMachine: {
-            ...stepFunctionEvent.StateMachine,
-            Id: 1,
-          },
-        },
-      ],
-      [
-        "StateMachine Name is not a string",
-        {
-          ...stepFunctionEvent,
-          StateMachine: {
-            ...stepFunctionEvent.StateMachine,
+            ...legacyStepFunctionEvent,
             Name: 1,
           },
         },
@@ -156,26 +89,15 @@ describe("StepFunctionContextService", () => {
       expect(instance.context).toBeUndefined();
     });
 
-    it("sets context from valid event", () => {
+    it("sets context from valid legacy event", () => {
       const instance = StepFunctionContextService.instance();
       // Force setting event
-      instance["setContext"](stepFunctionEvent);
+      instance["setContext"](legacyStepFunctionEvent);
       expect(instance.context).toEqual({
-        "step_function.execution_id":
+        execution_id:
           "arn:aws:states:sa-east-1:425362996713:express:logs-to-traces-sequential:85a9933e-9e11-83dc-6a61-b92367b6c3be:3f7ef5c7-c8b8-4c88-90a1-d54aa7e7e2bf",
-        "step_function.execution_input": {
-          MyInput: "MyValue",
-        },
-        "step_function.execution_name": "85a9933e-9e11-83dc-6a61-b92367b6c3be",
-        "step_function.execution_role_arn":
-          "arn:aws:iam::425362996713:role/service-role/StepFunctions-logs-to-traces-sequential-role-ccd69c03",
-        "step_function.execution_start_time": "2022-12-08T21:08:17.924Z",
-        "step_function.state_entered_time": "2022-12-08T21:08:19.224Z",
-        "step_function.state_machine_arn":
-          "arn:aws:states:sa-east-1:425362996713:stateMachine:logs-to-traces-sequential",
-        "step_function.state_machine_name": "my-state-machine",
-        "step_function.state_name": "step-one",
-        "step_function.state_retry_count": 2,
+        state_entered_time: "2022-12-08T21:08:19.224Z",
+        state_name: "step-one",
       });
     });
   });
@@ -185,10 +107,10 @@ describe("StepFunctionContextService", () => {
       jest.resetModules();
       StepFunctionContextService["_instance"] = undefined as any;
     });
-    it("returns a SpanContextWrapper when event is valid", () => {
+    it("returns a SpanContextWrapper when legacy event is valid", () => {
       const instance = StepFunctionContextService.instance();
       // Force setting event
-      instance["setContext"](stepFunctionEvent);
+      instance["setContext"](legacyStepFunctionEvent);
 
       const spanContext = instance.spanContext;
 
@@ -213,7 +135,7 @@ describe("StepFunctionContextService", () => {
     it("returns a SpanContextWrapper when event is from legacy lambda", () => {
       const instance = StepFunctionContextService.instance();
       // Force setting event
-      instance["setContext"]({ Payload: stepFunctionEvent });
+      instance["setContext"]({ Payload: legacyStepFunctionEvent });
 
       const spanContext = instance.spanContext;
 

--- a/src/trace/step-function-service.ts
+++ b/src/trace/step-function-service.ts
@@ -90,29 +90,26 @@ export class StepFunctionContextService {
     if (stateMachineContext === null) return;
     const { execution_id, state_entered_time, state_name } = stateMachineContext;
 
-    if (event.serverless_version === "string" && event.serverless_version == "v1") {
+    if (event.serverless_version === "string" && event.serverless_version === "v1") {
       const serverless_version = event.serverless_version;
 
       if (event.RootExecutionId === "string") {
-        const root_execution_id = event.RootExecutionId;
-
         this.context = {
           execution_id,
           state_entered_time,
           state_name,
-          root_execution_id,
+          root_execution_id: event.RootExecutionId,
           serverless_version,
         } as StepFunctionRootContext;
       } else if (event.trace_id === "string" && event.dd_p_tid === "string") {
-        const trace_id = event.trace_id;
-        const dd_p_tid = event.dd_p_tid;
+        const ptid = event["x-datadog-tags"]; // todo: parse me properly
 
         this.context = {
           execution_id,
           state_entered_time,
           state_name,
-          trace_id,
-          dd_p_tid,
+          trace_id: event["x-datadog-trace-id"],
+          dd_p_tid: ptid,
           serverless_version,
         } as LambdaRootContext;
       }
@@ -131,8 +128,8 @@ export class StepFunctionContextService {
       traceId = this.deterministicSha256HashToBigIntString(this.context.root_execution_id, TRACE_ID);
       ptid = this.deterministicSha256HashToBigIntString(this.context.root_execution_id, DD_P_TID);
     } else if (isLambdaRootContext(this.context)) {
-      traceId = this.context["trace_id"];
-      ptid = this.context["dd_p_tid"];
+      traceId = this.context.trace_id;
+      ptid = this.context.dd_p_tid;
     } else if (isLegacyContext(this.context)) {
       traceId = this.deterministicSha256HashToBigIntString(this.context.execution_id, TRACE_ID);
       ptid = this.deterministicSha256HashToBigIntString(this.context.execution_id, DD_P_TID);

--- a/src/trace/trigger.spec.ts
+++ b/src/trace/trigger.spec.ts
@@ -109,6 +109,14 @@ describe("parseEventSource", () => {
       },
       file: "sqs.json",
     },
+    {
+      result: {
+        "function_trigger.event_source": "states",
+        "function_trigger.event_source_arn":
+          "arn:aws:states:ca-central-1:425362996713:stateMachine:MyStateMachine-wsx8chv4d",
+      },
+      file: "states.json",
+    },
   ];
 
   const bufferedResponses = [

--- a/src/utils/event-type-guards.ts
+++ b/src/utils/event-type-guards.ts
@@ -106,3 +106,17 @@ export function isEventBridgeEvent(event: any): event is EventBridgeEvent<any, a
 export function isLambdaUrlEvent(event: any): boolean {
   return event?.requestContext?.domainName?.includes("lambda-url");
 }
+
+export function isStepFunctionsEvent(event: any): boolean {
+  // Extract Payload if available (Legacy lambda parsing)
+  if (typeof event.Payload === "object") {
+    event = event.Payload;
+  }
+  // Extract _datadog if available (JSONata v1 parsing)
+  if (typeof event._datadog === "object") {
+    event = event._datadog;
+  }
+  return (
+    typeof event.Execution === "object" && typeof event.State === "object" && typeof event.StateMachine === "object"
+  );
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

## What does this PR do?

Allows us to do multi-level trace merging between Step Functions and Node Lambda functions

### multi-level trace merging

![Screenshot 2024-11-15 at 3 00 58 PM](https://github.com/user-attachments/assets/2d80c713-3774-4361-a9ce-fe306e5b4ce4)

Added logic to extract trace context from `_datadog` for Step Functions cases where...
1. Root of the overall execution is a Lambda. This means we have the `x-datadog-trace-id` and `x-datadog-tags` but we need to compute the parentID using parent SFN context object
2. Root of the overall execution is another Step Function. This means we need to compute both traceID and parentID from `RootExecutionId` and the parent SFN context object
3. Legacy case where there's no `_datadog` and we instead figure out traceID and parentID from the parent SFN context object

### live testing
1. `Lambda1 --> SFN --> Lambda2` [trace](https://dd.datad0g.com/apm/trace/673b667c000000001440b57672af3118?graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5799951521693525512&timeHint=1731946108273.9214)
  a. Lambda1 is actually in Python, cool how we can mix and match runtimes
2. `SFN --> Lambda` [trace](https://dd.datad0g.com/apm/trace/7a46fcde4fa42b1b22dc17a341489db3?graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=3457008248562252968&timeHint=1731945399475)

### trigger tag improvements
Also fixed the trigger tags parsing for our use case!
<img width="410" alt="Screenshot 2024-11-18 at 10 41 44 AM" src="https://github.com/user-attachments/assets/56d55eb3-c30d-41f3-bb95-7fffd89e0d17">

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
