### PR TITLE
fix: Duplicate Payload Object in Input from SFN

### DIFF
--- a/src/trace/step-function-service.ts
+++ b/src/trace/step-function-service.ts
@@ -76,7 +76,10 @@ export class StepFunctionContextService {
     if (typeof event !== "object") return;
 
     // Extract Payload if available (Legacy lambda parsing)
-    if (typeof event.Payload === "object") {
+    if (
+      typeof event.Payload === "object" &&
+      (typeof event.Payload._datadog === "object" || this.isValidContextObject(event.Payload))
+    ) {
       event = event.Payload;
     }
 
@@ -199,25 +202,26 @@ export class StepFunctionContextService {
     state_entered_time: string;
     state_name: string;
   } | null {
-    const execution = event.Execution;
-    const state = event.State;
-
-    if (
-      typeof execution === "object" &&
-      typeof execution.Id === "string" &&
-      typeof state === "object" &&
-      typeof state.EnteredTime === "string" &&
-      typeof state.Name === "string"
-    ) {
+    if (this.isValidContextObject(event)) {
       return {
-        execution_id: execution.Id,
-        state_entered_time: state.EnteredTime,
-        state_name: state.Name,
+        execution_id: event.Execution.Id,
+        state_entered_time: event.State.EnteredTime,
+        state_name: event.State.Name,
       };
     }
 
     logDebug("Cannot extract StateMachine context! Invalid execution or state data.");
     return null;
+  }
+
+  private isValidContextObject(context: any): boolean {
+    return (
+      typeof context.Execution === "object" &&
+      typeof context.Execution.Id === "string" &&
+      typeof context.State === "object" &&
+      typeof context.State.EnteredTime === "string" &&
+      typeof context.State.Name === "string"
+    );
   }
 
   /**


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a guard clause around the code where we unpack the `Payload` object if it exists in the Step Functions event. There's an edge case where it isn't a Legacy Lambda object but customer's data may have a `Payload` in there

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
