### PR TITLE
Update span pointer imports from the tracer

### DIFF
--- a/src/utils/span-pointers.spec.ts
+++ b/src/utils/span-pointers.spec.ts
@@ -4,7 +4,7 @@ import { eventTypes } from "../trace/trigger";
 // tslint:disable-next-line:no-var-requires
 const { S3_PTR_KIND, SPAN_POINTER_DIRECTION } = require("dd-trace/packages/dd-trace/src/constants");
 // tslint:disable-next-line:no-var-requires
-const util = require("dd-trace/packages/dd-trace/src/util");
+const util = require("dd-trace/packages/datadog-plugin-aws-sdk/src/util");
 
 // Mock the external dependencies
 jest.mock("./log", () => ({

--- a/src/utils/span-pointers.ts
+++ b/src/utils/span-pointers.ts
@@ -38,7 +38,7 @@ function processS3Event(event: any): SpanPointerAttributes[] {
   let generatePointerHash;
   try {
     const constants = require("dd-trace/packages/dd-trace/src/constants");
-    const util = require("dd-trace/packages/dd-trace/src/util");
+    const util = require("dd-trace/packages/datadog-plugin-aws-sdk/src/util");
 
     ({ S3_PTR_KIND, SPAN_POINTER_DIRECTION } = constants);
     ({ generatePointerHash } = util);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Change the import location of `util` from the tracer.

### Motivation

https://github.com/DataDog/dd-trace-js/pull/4912 moves the location of our util files.

### Testing Guidelines

Manually testing

### Additional Notes

- Need to wait for a tracer release and bump the tracer version before the tests here will pass.
- We haven't yet done a release since the span pointer changes for S3 have been released, so this should not cause any version or failed import errors for our users. Even if it did, import errors are caught and logged

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
