### PR TITLE
Redrive Trace Merging Fix

### DIFF
--- a/src/trace/context/extractors/step-function.spec.ts
+++ b/src/trace/context/extractors/step-function.spec.ts
@@ -13,7 +13,6 @@ describe("StepFunctionEventTraceExtractor", () => {
         RoleArn:
           "arn:aws:iam::425362996713:role/service-role/StepFunctions-abhinav-activity-state-machine-role-22jpbgl6j",
         StartTime: "2024-12-04T19:38:04.069Z",
-        RedriveCount: 0,
       },
       State: {
         Name: "Lambda Invoke",

--- a/src/trace/step-function-service.spec.ts
+++ b/src/trace/step-function-service.spec.ts
@@ -110,16 +110,6 @@ describe("StepFunctionContextService", () => {
         },
       ],
       [
-        "Execution RedriveCount is not a number",
-        {
-          ...legacyStepFunctionEvent,
-          Execution: {
-            ...legacyStepFunctionEvent.Execution,
-            RedriveCount: "0",
-          },
-        },
-      ],
-      [
         "State is not defined",
         {
           ...legacyStepFunctionEvent,

--- a/src/trace/step-function-service.ts
+++ b/src/trace/step-function-service.ts
@@ -215,7 +215,7 @@ export class StepFunctionContextService {
     if (this.isValidContextObject(event)) {
       return {
         execution_id: event.Execution.Id,
-        redrive_count: event.Execution.RedriveCount.toString(),
+        redrive_count: (event.Execution.RedriveCount ?? "0").toString(),
         state_entered_time: event.State.EnteredTime,
         state_name: event.State.Name,
       };
@@ -228,7 +228,6 @@ export class StepFunctionContextService {
   private isValidContextObject(context: any): boolean {
     return (
       typeof context?.Execution?.Id === "string" &&
-      typeof context?.Execution?.RedriveCount === "number" &&
       typeof context?.State?.EnteredTime === "string" &&
       typeof context?.State?.Name === "string"
     );


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Account for missing redrive count in Step Functions trace merging. While we expect the context object to always have `Execution.RedriveCount`, some customers context objects don't have this value.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
