### PR TITLE
Move span pointer to inferred span; add env var to toggle span pointers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export const coldStartTracingEnvVar = "DD_COLD_START_TRACING";
 export const minColdStartTraceDurationEnvVar = "DD_MIN_COLD_START_DURATION";
 export const coldStartTraceSkipLibEnvVar = "DD_COLD_START_TRACE_SKIP_LIB";
 export const localTestingEnvVar = "DD_LOCAL_TESTING";
+export const addSpanPointersEnvVar = "DD_TRACE_AWS_ADD_SPAN_POINTERS"
 
 interface GlobalConfig {
   /**
@@ -93,6 +94,7 @@ export const defaultConfig: Config = {
   minColdStartTraceDuration: 3,
   coldStartTraceSkipLib: "",
   localTesting: false,
+  addSpanPointers: true,
 } as const;
 
 export const _metricsQueue: MetricsQueue = new MetricsQueue();
@@ -404,6 +406,11 @@ function getConfig(userConfig?: Partial<Config>): Config {
     // but the extension allows it, so we must as well
     // @ts-ignore-next-line
     config.localTesting = result === "true" || result === "1";
+  }
+
+  if (userConfig === undefined || userConfig.addSpanPointers === undefined) {
+    const result = getEnvValue(addSpanPointersEnvVar, "true").toLowerCase();
+    config.addSpanPointers = result === "true";
   }
 
   return config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export const coldStartTracingEnvVar = "DD_COLD_START_TRACING";
 export const minColdStartTraceDurationEnvVar = "DD_MIN_COLD_START_DURATION";
 export const coldStartTraceSkipLibEnvVar = "DD_COLD_START_TRACE_SKIP_LIB";
 export const localTestingEnvVar = "DD_LOCAL_TESTING";
-export const addSpanPointersEnvVar = "DD_TRACE_AWS_ADD_SPAN_POINTERS"
+export const addSpanPointersEnvVar = "DD_TRACE_AWS_ADD_SPAN_POINTERS";
 
 interface GlobalConfig {
   /**

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -78,6 +78,7 @@ describe("TraceListener", () => {
     injectLogContext: false,
     minColdStartTraceDuration: 3,
     coldStartTraceSkipLib: "",
+    addSpanPointers: true,
   };
   const context = {
     invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789101:function:my-lambda",

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -210,7 +210,11 @@ export class TraceListener {
 
     if (this.inferredSpan && this.spanPointerAttributesList) {
       for (const attributes of this.spanPointerAttributesList) {
-        this.inferredSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
+        try {
+          this.inferredSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
+        } catch (e) {
+          logDebug("Failed to add span pointer")
+        }
       }
     }
     return false;

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -208,9 +208,9 @@ export class TraceListener {
       }
     }
 
-    if (this.wrappedCurrentSpan && this.spanPointerAttributesList) {
+    if (this.inferredSpan && this.spanPointerAttributesList) {
       for (const attributes of this.spanPointerAttributesList) {
-        this.wrappedCurrentSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
+        this.inferredSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
       }
     }
     return false;

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -213,7 +213,7 @@ export class TraceListener {
         try {
           this.inferredSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
         } catch (e) {
-          logDebug("Failed to add span pointer")
+          logDebug("Failed to add span pointer");
         }
       }
     }

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -69,6 +69,11 @@ export interface TraceConfig {
    * Libraries to ignore from cold start traces
    */
   coldStartTraceSkipLib: string;
+  /**
+   * Whether to enable span pointers
+   * @default true
+   */
+  addSpanPointers: boolean;
 }
 
 export class TraceListener {
@@ -137,7 +142,9 @@ export class TraceListener {
     this.triggerTags = extractTriggerTags(event, context, eventSource);
     this.stepFunctionContext = StepFunctionContextService.instance().context;
 
-    this.spanPointerAttributesList = getSpanPointerAttributes(eventSource, event);
+    if (this.config.addSpanPointers) {
+      this.spanPointerAttributesList = getSpanPointerAttributes(eventSource, event);
+    }
   }
 
   /**

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -208,10 +208,14 @@ export class TraceListener {
       }
     }
 
-    if (this.inferredSpan && this.spanPointerAttributesList) {
+    let rootSpan = this.inferredSpan;
+    if (!rootSpan) {
+      rootSpan = this.wrappedCurrentSpan;
+    }
+    if (this.spanPointerAttributesList) {
       for (const attributes of this.spanPointerAttributesList) {
         try {
-          this.inferredSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
+          rootSpan.span.addSpanPointer(attributes.kind, attributes.direction, attributes.hash);
         } catch (e) {
           logDebug("Failed to add span pointer");
         }

--- a/src/utils/span-pointers.ts
+++ b/src/utils/span-pointers.ts
@@ -114,7 +114,7 @@ function processDynamoDbEvent(event: any): SpanPointerAttributes[] {
 
     const keys = record.dynamodb?.Keys;
     const eventSourceARN = record.eventSourceARN;
-    const tableName = record.eventSourceARN ? getTableNameFromARN(eventSourceARN) : undefined;
+    const tableName = eventSourceARN ? getTableNameFromARN(eventSourceARN) : undefined;
 
     if (!tableName || !keys) {
       logDebug("Unable to calculate hash because of missing parameters.");


### PR DESCRIPTION
### What does this PR do?

1. Adds an env var `DD_TRACE_AWS_ADD_SPAN_POINTERS` to toggle span pointers
2. Put span pointers on inferred (root) span instead of the lambda (child) span, as discussed in Slack.
3. Wrap `span.addSpanPointers` with try/catch, since `span` is of type any.

Note that moving the location of the span pointer has no actual effect on the functionality and requires no changes on the UI side. As long as a span is found with a matching hash, span pointers work. Since the spans are on the same trace, this has no noticeable change for our users. This change just aligns span pointers with bottlecap (universally instrumented) runtimes.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Manual testing. The span links are now on the root (inferred) span.
<img width="1029" alt="Screenshot 2025-01-16 at 10 39 48 AM" src="https://github.com/user-attachments/assets/18eb83e9-1621-444b-87c0-ee438e55d6fc" />

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
