### PR TITLE
precompile the v8 compile cache when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,8 @@ RUN find /nodejs/node_modules -name "*.cjs.map" -delete
 RUN find /nodejs/node_modules -name "*.ts.map" -delete
 RUN find /nodejs/node_modules -name "*.md" -delete
 
+# Warm up compile cache
+RUN node -e "require('/nodejs/node_modules/datadog-lambda-js/runtime/module_importer').initTracer()"
+
 FROM scratch
 COPY --from=builder /nodejs /

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "hot-shots": "8.5.0",
     "promise-retry": "^2.0.1",
     "serialize-error": "^8.1.0",
-    "shimmer": "1.2.1"
+    "shimmer": "1.2.1",
+    "v8-compile-cache": "^2.4.0"
   },
   "jest": {
     "verbose": true,

--- a/src/runtime/module_importer.js
+++ b/src/runtime/module_importer.js
@@ -1,6 +1,25 @@
 
 const { logDebug, updateDDTags } = require("../utils");
 
+function compileCache () {
+    const { FileSystemBlobStore, NativeCompileCache } = require('v8-compile-cache').__TEST__
+
+    const cacheDir = __dirname
+    const prefix = 'module_importer'
+    const blobStore = new FileSystemBlobStore(cacheDir, prefix)
+
+    const nativeCompileCache = new NativeCompileCache()
+    nativeCompileCache.setCacheStore(blobStore)
+    nativeCompileCache.install()
+
+    process.once('exit', () => {
+        if (blobStore.isDirty()) {
+        blobStore.save()
+        }
+        nativeCompileCache.uninstall()
+    })
+}
+
 // Currently no way to prevent typescript from auto-transpiling import into require,
 // so we expose a wrapper in js
 exports.import = function (path) {
@@ -8,6 +27,8 @@ exports.import = function (path) {
 }
 
 exports.initTracer = function () {
+    compileCache()
+
     // Looks for the function local version of dd-trace first, before using
     // the version provided by the layer
     const path = require.resolve("dd-trace", { paths: ["/var/task/node_modules", ...module.paths] });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,6 +4075,11 @@ uuid@^9.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
+v8-compile-cache@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
+  integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
+
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz#77b752fd3975e31bbcef938f85e9bd1c7a8d60ed"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Precompile the v8 compile cache when building.

### Motivation

<!--- What inspired you to submit this pull request? --->

This improves cold start time, and can be done for Lambda even though the cache is unique to a specific Node version and OS because the environment is known.

### Testing Guidelines

<!--- How did you test this pull request? --->

All this does is precompile the cache, so only benchmarks should be affected.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
