### PR TITLE
Extract API Key from Secrets Manager when using the metrics API client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { SpanOptions, TracerWrapper } from "./trace/tracer-wrapper";
 export { DatadogTraceHeaders as TraceHeaders } from "./trace/context/extractor";
 export const apiKeyEnvVar = "DD_API_KEY";
 export const apiKeyKMSEnvVar = "DD_KMS_API_KEY";
-export const apiKeySecretARNEnvVar = "DD_API_KEY_SECRET_ARN"
+export const apiKeySecretARNEnvVar = "DD_API_KEY_SECRET_ARN";
 export const captureLambdaPayloadEnvVar = "DD_CAPTURE_LAMBDA_PAYLOAD";
 export const captureLambdaPayloadMaxDepthEnvVar = "DD_CAPTURE_LAMBDA_PAYLOAD_MAX_DEPTH";
 export const traceManagedServicesEnvVar = "DD_TRACE_MANAGED_SERVICES";

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { SpanOptions, TracerWrapper } from "./trace/tracer-wrapper";
 export { DatadogTraceHeaders as TraceHeaders } from "./trace/context/extractor";
 export const apiKeyEnvVar = "DD_API_KEY";
 export const apiKeyKMSEnvVar = "DD_KMS_API_KEY";
+export const apiKeySecretARNEnvVar = "DD_API_KEY_SECRET_ARN"
 export const captureLambdaPayloadEnvVar = "DD_CAPTURE_LAMBDA_PAYLOAD";
 export const captureLambdaPayloadMaxDepthEnvVar = "DD_CAPTURE_LAMBDA_PAYLOAD_MAX_DEPTH";
 export const traceManagedServicesEnvVar = "DD_TRACE_MANAGED_SERVICES";
@@ -76,6 +77,7 @@ export type Config = MetricsConfig & TraceConfig & GlobalConfig;
 export const defaultConfig: Config = {
   apiKey: "",
   apiKeyKMS: "",
+  apiKeySecretARN: "",
   autoPatchHTTP: true,
   captureLambdaPayload: false,
   captureLambdaPayloadMaxDepth: 10,
@@ -342,6 +344,10 @@ function getConfig(userConfig?: Partial<Config>): Config {
 
   if (config.apiKeyKMS === "") {
     config.apiKeyKMS = getEnvValue(apiKeyKMSEnvVar, "");
+  }
+
+  if (config.apiKeySecretARN === "") {
+    config.apiKeySecretARN = getEnvValue(apiKeySecretARNEnvVar, "");
   }
 
   if (userConfig === undefined || userConfig.injectLogContext === undefined) {

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -9,6 +9,14 @@ import StatsDClient from "hot-shots";
 import { Context } from "aws-lambda";
 jest.mock("hot-shots");
 
+jest.mock("aws-sdk/clients/secretsmanager", () => {
+  return jest.fn().mockImplementation(() => ({
+    getSecretValue: jest.fn().mockResolvedValue({
+      SecretString: "api-key-secret",
+    }),
+  }));
+});
+
 const siteURL = "example.com";
 
 class MockKMS {
@@ -69,6 +77,29 @@ describe("MetricsListener", () => {
 
     expect(nock.isDone()).toBeTruthy();
   });
+
+  it("extracts the API Key from the secret manager to send a metric", async () => {
+    nock("https://api.example.com").post("/api/v1/distribution_points?api_key=api-key-secret").reply(200, {});
+
+    const kms = new MockKMS("kms-api-key-decrypted");
+    const listener = new MetricsListener(kms as any, {
+      apiKey: "",
+      apiKeyKMS: "",
+      apiKeySecretARN: "api-key-secret-arn",
+      enhancedMetrics: false,
+      logForwarding: false,
+      shouldRetryMetrics: false,
+      localTesting: false,
+      siteURL,
+    });
+
+    await listener.onStartInvocation({});
+    listener.sendDistributionMetricWithDate("my-metric", 10, new Date(), false, "tag:a", "tag:b");
+    await listener.onCompleteInvocation();
+
+    expect(nock.isDone()).toBeTruthy();
+  });
+
   it("doesn't throw an error if it can't get a valid apiKey", async () => {
     const kms = new MockKMS("kms-api-key-decrypted", new Error("The error"));
     const listener = new MetricsListener(kms as any, {

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -34,6 +34,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "kms-api-key-encrypted",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
@@ -54,6 +55,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "",
       apiKeyKMS: "kms-api-key-encrypted",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
@@ -72,6 +74,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "",
       apiKeyKMS: "kms-api-key-encrypted",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
@@ -91,6 +94,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "kms-api-key-encrypted",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: true,
       shouldRetryMetrics: false,
@@ -124,6 +128,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: true,
       shouldRetryMetrics: false,
@@ -159,6 +164,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
@@ -198,6 +204,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
@@ -219,6 +226,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "kms-api-key-encrypted",
+      apiKeySecretARN: "api-key-secret-arn",
       enhancedMetrics: false,
       logForwarding: true,
       shouldRetryMetrics: false,

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -11,8 +11,10 @@ jest.mock("hot-shots");
 
 jest.mock("aws-sdk/clients/secretsmanager", () => {
   return jest.fn().mockImplementation(() => ({
-    getSecretValue: jest.fn().mockResolvedValue({
-      SecretString: "api-key-secret",
+    getSecretValue: jest.fn().mockReturnValue({
+      promise: jest.fn().mockResolvedValue({
+        SecretString: "api-key-secret",
+      }),
     }),
   }));
 });

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -224,7 +224,11 @@ export class MetricsListener {
       try {
         const secretsClient = require("aws-sdk/clients/secretsmanager");
         const secretsManager = new secretsClient();
-        const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });
+        const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN }).promise();
+        if (secret === undefined || secret.SecretString === undefined) {
+          console.log("=================== TODO DYLAN delete")
+          console.log({secret})
+        }
         return secret.SecretString;
       } catch (error) {
         logError("couldn't get secrets manager api key", error as Error);

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -226,8 +226,8 @@ export class MetricsListener {
         const secretsManager = new secretsClient();
         const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN }).promise();
         if (secret === undefined || secret.SecretString === undefined) {
-          console.log("=================== TODO DYLAN delete")
-          console.log({secret})
+          console.log("=================== TODO DYLAN delete");
+          console.log({ secret });
         }
         return secret.SecretString;
       } catch (error) {

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -29,6 +29,10 @@ export interface MetricsConfig {
    */
   apiKeyKMS: string;
   /**
+   * An api key stored in secrets manager used to talk to the Datadog API.
+   */
+  apiKeySecretARN: string;
+  /**
    * The site of the Datadog URL to send to. This should either be 'datadoghq.com', (default),
    * or 'datadoghq.eu', for customers in the eu.
    * @default "datadoghq.com"
@@ -213,6 +217,17 @@ export class MetricsListener {
         return await this.kmsClient.decrypt(config.apiKeyKMS);
       } catch (error) {
         logError("couldn't decrypt kms api key", error as Error);
+      }
+    }
+
+    if (config.apiKeySecretARN !== "") {
+      try {
+        const secretsClient = require("aws-sdk/clients/secretsmanager");
+        const secretsManager = new secretsClient();
+        const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });
+        return secret.SecretString;
+      } catch (error) {
+        logError("couldn't get secrets api key", error as Error);
       }
     }
     return "";

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -225,10 +225,6 @@ export class MetricsListener {
         const secretsClient = require("aws-sdk/clients/secretsmanager");
         const secretsManager = new secretsClient();
         const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN }).promise();
-        if (secret === undefined || secret.SecretString === undefined) {
-          console.log("=================== TODO DYLAN delete");
-          console.log({ secret });
-        }
         return secret.SecretString;
       } catch (error) {
         logError("couldn't get secrets manager api key", error as Error);

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -227,7 +227,7 @@ export class MetricsListener {
         const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });
         return secret.SecretString;
       } catch (error) {
-        logError("couldn't get secrets api key", error as Error);
+        logError("couldn't get secrets manager api key", error as Error);
       }
     }
     return "";


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Respects `DD_API_KEY_SECRET_ARN` as an API key parameter when using the DD metrics API client since this logic was never added.

### Motivation

<!--- What inspired you to submit this pull request? --->
#577 - permission errors are thrown for Secrets Manager when using `sendDistributionMetricWithDate()` and `DD_API_KEY_SECRET_ARN`. 

### Testing Guidelines

<!--- How did you test this pull request? --->
Adds a unit test for secrets manager

### Additional Notes

SVLS-5679

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
