### PR TITLE
[gitlab] Get secrets from vault

### DIFF
--- a/.gitlab/scripts/get_secrets.sh
+++ b/.gitlab/scripts/get_secrets.sh
@@ -21,21 +21,11 @@ fi
 
 printf "Getting AWS External ID...\n"
 
-EXTERNAL_ID=$(aws ssm get-parameter \
-    --region us-east-1 \
-    --name "ci.datadog-lambda-js.$EXTERNAL_ID_NAME" \
-    --with-decryption \
-    --query "Parameter.Value" \
-    --out text)
+EXTERNAL_ID=$(vault kv get -field=$EXTERNAL_ID_NAME kv/k8s/gitlab-runner/datadog-lambda-js/secrets)
 
 printf "Getting DD API KEY...\n"
 
-export DD_API_KEY=$(aws ssm get-parameter \
-    --region us-east-1 \
-    --name ci.datadog-lambda-js.dd-api-key \
-    --with-decryption \
-    --query "Parameter.Value" \
-    --out text)
+export DD_API_KEY=$(vault kv get -field=dd-api-key kv/k8s/gitlab-runner/datadog-lambda-js/secrets)
 
 printf "Assuming role...\n"
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Migrates secret storage from AWS SSM to Vault.
Secrets: https://vault.us1.ddbuild.io/ui/vault/secrets/kv/kv/k8s%2Fgitlab-runner%2Fdatadog-lambda-js%2Fsecrets/details?version=2

### Motivation

Proper secret storage in Gitlab: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3826647944/Secure+Storage+and+Handling+of+Secrets#In-GitLab

### Testing Guidelines

- Integration tests passed, so the `vault kv get -field=dd-api-key` works
- I published to a random region in sandbox successfully, so the `vault kv get -field=$EXTERNAL_ID_NAME` works. https://gitlab.ddbuild.io/DataDog/datadog-lambda-js/-/jobs/807550522

### Additional Notes

Related PR: https://github.com/DataDog/vault-config/pull/7119

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
