### PR TITLE
Create bundle and publish to govcloud script

### DIFF
--- a/.gitlab/scripts/publish_layers.sh
+++ b/.gitlab/scripts/publish_layers.sh
@@ -95,14 +95,18 @@ if [[ "$STAGE" =~ ^(staging|sandbox)$ ]]; then
 else
     # Running on prod
     if [ -z "$CI_COMMIT_TAG" ]; then
-        printf "[Error] No CI_COMMIT_TAG found.\n"
-        printf "Exiting script...\n"
-        exit 1
+        # this happens during manual govcloud releases.
+        if [ -z "$VERSION" ]; then
+            printf "[Error] No CI_COMMIT_TAG or VERSION found.\n"
+            printf "Exiting script...\n"
+            exit 1
+        else
+            printf "Using provided VERSION: $VERSION\n"
+        fi
     else
         printf "Tag found in environment: $CI_COMMIT_TAG\n"
+        VERSION=$(echo "${CI_COMMIT_TAG##*v}" | cut -d. -f2)
     fi
-
-    VERSION=$(echo "${CI_COMMIT_TAG##*v}" | cut -d. -f2)
 fi
 
 # Target layer version

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -1,0 +1,128 @@
+#! /usr/bin/env bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025 Datadog, Inc.
+#
+# USAGE: download the layer bundle from the build pipeline in gitlab. Use the
+# Download button on the `layer bundle` job. This will be a zip file containing
+# all of the required layers. Run this script as follows:
+#
+# ENVIRONMENT=[us1-staging-fed or us1-fed] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
+#
+# protip: you can drag the zip file from finder into your terminal to insert
+# its path.
+
+set -e
+
+NODE_VERSIONS=("18.12" "20.9" "22.11")
+
+LAYER_PACKAGE=$1
+
+if [ -z "$LAYER_PACKAGE" ]; then
+    printf "[ERROR]: layer package not provided\n"
+    exit 1
+fi
+
+PACKAGE_NAME=$(basename "$LAYER_PACKAGE" .zip)
+echo package name: $PACKAGE_NAME
+
+if [ -z "$ENVIRONMENT" ]; then
+    printf "[ERROR]: ENVIRONMENT not specified\n"
+    exit 1
+fi
+
+if [ "$ENVIRONMENT" = "us1-staging-fed" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-us1-staging-fed-power-user
+
+# this role looks like this in ~/.aws/config:
+# [profile sso-govcloud-us1-staging-fed-power-user]
+# sso_start_url=https://start.us-gov-home.awsapps.com/directory/d-9867188aeb
+# sso_account_id=553727695824
+# sso_role_name=power-user
+# sso_region=us-gov-west-1
+# region=us-gov-west-1
+
+    export STAGE="sandbox"
+    export ADD_LAYER_VERSION_PERMISSIONS=0
+    export AUTOMATICALLY_BUMP_VERSION=1
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_lambda_js-(signed-)?bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
+elif [ $ENVIRONMENT = "us1-fed" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-us1-fed-engineering
+
+# this role looks like this in ~/.aws/config:
+# [profile sso-govcloud-us1-fed-engineering]
+# sso_start_url=https://start.us-gov-west-1.us-gov-home.awsapps.com/directory/d-98671fdc8b
+# sso_account_id=002406178527
+# sso_role_name=engineering
+# sso_region=us-gov-west-1
+# region=us-gov-west-1
+
+    export STAGE="prod"
+    export ADD_LAYER_VERSION_PERMISSIONS=1
+    export AUTOMATICALLY_BUMP_VERSION=0
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_lambda_js-signed-bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
+else
+    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed or us1-fed.\n"
+    exit 1
+fi
+
+# Clean and recreate the .layers directory
+echo "Cleaning .layers directory..."
+rm -rf .layers
+mkdir -p .layers
+
+echo "Copying layer files to .layers directory..."
+TEMP_DIR=$(mktemp -d)
+unzip $LAYER_PACKAGE -d $TEMP_DIR
+cp -v $TEMP_DIR/$PACKAGE_NAME/*.zip .layers/
+
+
+AWS_VAULT_PREFIX="aws-vault exec $AWS_VAULT_ROLE --"
+
+echo "Checking that you have access to the GovCloud AWS account"
+$AWS_VAULT_PREFIX aws sts get-caller-identity
+
+
+AVAILABLE_REGIONS=$($AWS_VAULT_PREFIX aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
+
+# Determine the target regions
+if [ -z "$REGIONS" ]; then
+    echo "Region not specified, running for all available regions."
+    REGIONS=$AVAILABLE_REGIONS
+else
+    echo "Region specified: $REGIONS"
+    if [[ ! "$AVAILABLE_REGIONS" == *"$REGIONS"* ]]; then
+        echo "Could not find $REGIONS in available regions: $AVAILABLE_REGIONS"
+        echo ""
+        echo "EXITING SCRIPT."
+        exit 1
+    fi
+fi
+
+for region in $REGIONS
+do
+    echo "Starting publishing layers for region $region..."
+
+    for NODE_VERSION in "${NODE_VERSIONS[@]}"; do
+        echo "Publishing Layer for Node ${NODE_VERSION} in region ${region}"
+
+        # Set environment variables for the publish script
+        export REGION=$region
+        export NODE_VERSION=$NODE_VERSION
+
+        # Run the publish script with AWS credentials
+        $AWS_VAULT_PREFIX .gitlab/scripts/publish_layers.sh
+    done
+done
+
+echo "Done!"

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -45,8 +45,6 @@ if [ "$ENVIRONMENT" = "us1-staging-fed" ]; then
 # region=us-gov-west-1
 
     export STAGE="sandbox"
-    export ADD_LAYER_VERSION_PERMISSIONS=0
-    export AUTOMATICALLY_BUMP_VERSION=1
     if [[ ! "$PACKAGE_NAME" =~ ^datadog_lambda_js-(signed-)?bundle-[0-9]+$ ]]; then
         echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
         exit 1
@@ -64,8 +62,6 @@ elif [ $ENVIRONMENT = "us1-fed" ]; then
 # region=us-gov-west-1
 
     export STAGE="prod"
-    export ADD_LAYER_VERSION_PERMISSIONS=1
-    export AUTOMATICALLY_BUMP_VERSION=0
     if [[ ! "$PACKAGE_NAME" =~ ^datadog_lambda_js-signed-bundle-[0-9]+$ ]]; then
         echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
         exit 1


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Creates a job in Gitlab to bundle all the layer zips into a single zip so we no longer have to manually download each layer manually.

This PR also creates `scripts/publish_govcloud_layers.sh` to publish layers to either Govcloud or Govcloud staging.

### Motivation

Copying logic from https://github.com/DataDog/datadog-lambda-extension/pull/556/

Easier testing of layers for FIPs compliance + easier time publishing to Govcloud

### Testing Guidelines

Manually.

Layer bundle passed:
<img width="500" alt="Screenshot 2025-02-28 at 11 56 31 AM" src="https://github.com/user-attachments/assets/4e7a8fca-1456-49ce-9aee-270c2f872341" />

and produces the correct artifact as expected:
<img width="500" alt="Screenshot 2025-02-28 at 11 56 53 AM" src="https://github.com/user-attachments/assets/5def7a4e-35d1-45e9-b36e-05dadfb3d843" />

and running the script (on staging) works as expected:
```sh
ENVIRONMENT=us1-staging-fed REGIONS=us-gov-west-1 ./scripts/publish_govcloud_layers.sh <path from dragging bundle.zip file>
```
<img width="1123" alt="Screenshot 2025-02-28 at 11 58 02 AM" src="https://github.com/user-attachments/assets/83e10674-497a-4af8-82dc-7a83a428f7d6" />

### Additional Notes

Basically all the same logic as the datadog-lambda-extension implementation. But there is no 'flavors' since each layer works on both arm64 and amd64 Lambdas.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
