### PR TITLE
Use FIPs endpoint for SecretManager when in Govcloud region

### DIFF
--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -141,7 +141,7 @@ describe("MetricsListener", () => {
 
       expect(secretsManagerSpy).toHaveBeenCalledWith({
         useFipsEndpoint: true,
-        region: "us-gov-west-1"
+        region: "us-gov-west-1",
       });
 
       secretsManagerSpy.mockRestore();

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -141,7 +141,6 @@ describe("MetricsListener", () => {
 
       expect(secretsManagerSpy).toHaveBeenCalledWith({
         useFipsEndpoint: true,
-        region: "us-gov-west-1",
       });
 
       secretsManagerSpy.mockRestore();

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -118,6 +118,38 @@ describe("MetricsListener", () => {
     await expect(listener.onCompleteInvocation()).resolves.toEqual(undefined);
   });
 
+  it("configures FIPS endpoint for GovCloud regions", async () => {
+    try {
+      process.env.AWS_REGION = "us-gov-west-1";
+      const secretsManagerModule = require("@aws-sdk/client-secrets-manager");
+      const secretsManagerSpy = jest.spyOn(secretsManagerModule, "SecretsManager");
+
+      const kms = new MockKMS("kms-api-key-decrypted");
+      const listener = new MetricsListener(kms as any, {
+        apiKey: "",
+        apiKeyKMS: "",
+        apiKeySecretARN: "api-key-secret-arn",
+        enhancedMetrics: false,
+        logForwarding: false,
+        shouldRetryMetrics: false,
+        localTesting: false,
+        siteURL,
+      });
+
+      await listener.onStartInvocation({});
+      await listener.onCompleteInvocation();
+
+      expect(secretsManagerSpy).toHaveBeenCalledWith({
+        useFipsEndpoint: true,
+        region: "us-gov-west-1"
+      });
+
+      secretsManagerSpy.mockRestore();
+    } finally {
+      process.env.AWS_REGION = "us-east-1";
+    }
+  });
+
   it("logs metrics when logForwarding is enabled", async () => {
     const spy = jest.spyOn(process.stdout, "write");
     jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -225,15 +225,10 @@ export class MetricsListener {
       try {
         const { SecretsManager } = await import("@aws-sdk/client-secrets-manager");
         const region = process.env.AWS_REGION;
-        let secretsParams: SecretsManagerClientConfig = {};
-        if (region) {
-          const isGovRegion = region.startsWith("us-gov-");
-          secretsParams = {
-            useFipsEndpoint: isGovRegion,
-            region,
-          };
-        }
-        const secretsManager = new SecretsManager(secretsParams);
+        const isGovRegion = region !== undefined && region.startsWith("us-gov-");
+        const secretsManager = new SecretsManager({
+          useFipsEndpoint: isGovRegion,
+        });
         const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });
         return secret?.SecretString ?? "";
       } catch (error) {

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -231,7 +231,7 @@ export class MetricsListener {
           secretsParams = {
             useFipsEndpoint: isGovRegion,
             region,
-          }
+          };
         }
         const secretsManager = new SecretsManager(secretsParams);
         const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });


### PR DESCRIPTION
### What does this PR do?

When creating the `SecretsManager` client, set `useFipsEndpoint` to true if in a govcloud region.

Will get to KMS key storage in a following PR.

### Motivation

Making our products FIPs compliant.

### Testing Guidelines

Manually. Secrets manager works in both Govcloud and commercial regions.

Added a simple unit test

### Additional Notes


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
