### PR TITLE
Use FIPs endpoint for KMS when in Govcloud region

### DIFF
--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -129,8 +129,8 @@ describe("KMSService", () => {
       jest.mock("aws-sdk/clients/kms", () => mockKmsConstructor);
       mockKmsConstructor.mockImplementation(() => ({
         decrypt: () => ({
-          promise: () => Promise.resolve({ Plaintext: Buffer.from(EXPECTED_RESULT) })
-        })
+          promise: () => Promise.resolve({ Plaintext: Buffer.from(EXPECTED_RESULT) }),
+        }),
       }));
 
       // Create service and call decrypt
@@ -139,9 +139,8 @@ describe("KMSService", () => {
 
       // Verify FIPS endpoint was used
       expect(mockKmsConstructor).toHaveBeenCalledWith({
-        endpoint: "https://kms-fips.us-gov-west-1.amazonaws.com"
+        endpoint: "https://kms-fips.us-gov-west-1.amazonaws.com",
       });
-
     } finally {
       process.env.AWS_REGION = "us-east-1";
       jest.restoreAllMocks();

--- a/src/metrics/kms-service.spec.ts
+++ b/src/metrics/kms-service.spec.ts
@@ -100,7 +100,7 @@ describe("KMSService", () => {
       });
 
     const kmsService = new KMSService();
-    const result = await kmsService.decryptV3(Buffer.from(ENCRYPTED_KEY, "base64"));
+    const result = await kmsService.decryptV3(Buffer.from(ENCRYPTED_KEY, "base64"), {});
     expect(Buffer.from(result).toString("ascii")).toEqual(EXPECTED_RESULT);
     fakeKmsCall.done();
   });
@@ -116,8 +116,35 @@ describe("KMSService", () => {
       });
 
     const kmsService = new KMSService();
-    const result = await kmsService.decryptV3(Buffer.from(ENCRYPTED_KEY, "base64"));
+    const result = await kmsService.decryptV3(Buffer.from(ENCRYPTED_KEY, "base64"), {});
     expect(Buffer.from(result).toString("ascii")).toEqual(EXPECTED_RESULT);
     fakeKmsCall.done();
+  });
+
+  it("configures FIPS endpoint for GovCloud regions", async () => {
+    try {
+      process.env.AWS_REGION = "us-gov-west-1";
+
+      const mockKmsConstructor = jest.fn();
+      jest.mock("aws-sdk/clients/kms", () => mockKmsConstructor);
+      mockKmsConstructor.mockImplementation(() => ({
+        decrypt: () => ({
+          promise: () => Promise.resolve({ Plaintext: Buffer.from(EXPECTED_RESULT) })
+        })
+      }));
+
+      // Create service and call decrypt
+      const kmsService = new KMSService();
+      await kmsService.decrypt(ENCRYPTED_KEY);
+
+      // Verify FIPS endpoint was used
+      expect(mockKmsConstructor).toHaveBeenCalledWith({
+        endpoint: "https://kms-fips.us-gov-west-1.amazonaws.com"
+      });
+
+    } finally {
+      process.env.AWS_REGION = "us-east-1";
+      jest.restoreAllMocks();
+    }
   });
 });

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -17,7 +17,7 @@ export class KMSService {
     const region = process.env.AWS_REGION;
     const isGovRegion = region !== undefined && region.startsWith("us-gov-");
     if (isGovRegion) {
-      logDebug("Govcloud region detected. Using FIPs endpoints for secrets management.")
+      logDebug("Govcloud region detected. Using FIPs endpoints for secrets management.");
     }
     let kmsClientParams = {};
     if (isGovRegion) {

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -14,12 +14,12 @@ export class KMSService {
 
     const region = process.env.AWS_REGION;
     const isGovRegion = region !== undefined && region.startsWith("us-gov-");
-    let kmsClientParams = {}
+    let kmsClientParams = {};
     if (isGovRegion) {
       // Endpoints: https://docs.aws.amazon.com/general/latest/gr/kms.html
       kmsClientParams = {
         endpoint: `https://kms-fips.${region}.amazonaws.com`,
-      }
+      };
     }
 
     // Explicitly try/catch this require to appease esbuild and ts compiler

--- a/src/metrics/kms-service.ts
+++ b/src/metrics/kms-service.ts
@@ -1,6 +1,8 @@
 // In order to avoid the layer adding the 40mb aws-sdk to a deployment, (which is always available
 // in the Lambda environment anyway), we use require to import the SDK.
 
+import { logDebug } from "../utils";
+
 export class KMSService {
   private encryptionContext;
 
@@ -14,6 +16,9 @@ export class KMSService {
 
     const region = process.env.AWS_REGION;
     const isGovRegion = region !== undefined && region.startsWith("us-gov-");
+    if (isGovRegion) {
+      logDebug("Govcloud region detected. Using FIPs endpoints for secrets management.")
+    }
     let kmsClientParams = {};
     if (isGovRegion) {
       // Endpoints: https://docs.aws.amazon.com/general/latest/gr/kms.html


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

When creating the `kmsClient`, set `useFipsEndpoint` to true if in a govcloud region.

### Motivation

Making our products FIPs compliant.

### Testing Guidelines

Manually. Works in both Govcloud and commercial regions.

### Additional Notes

Related PR: https://github.com/DataDog/datadog-lambda-js/pull/634

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
