### PR TITLE
chore: upgrade tracer to `v5.41.1`

### DIFF
--- a/integration_tests/snapshots/logs/process-input-traced_node18.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node18.log
@@ -48,6 +48,7 @@ START
           "_inferred_span.synchronicity": "sync",
           "http.method": "GET",
           "stage": "test",
+          "domain_name": "",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
@@ -81,6 +82,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
@@ -191,6 +193,7 @@ START
         "resource": "MODIFY someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -230,7 +233,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -240,6 +242,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
@@ -343,6 +346,7 @@ START
         "resource": "REMOVE someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -382,7 +386,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -392,6 +395,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
@@ -495,6 +499,7 @@ START
         "resource": "INSERT someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -534,7 +539,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -544,6 +548,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
@@ -647,6 +652,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -685,7 +691,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -695,6 +700,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -778,6 +784,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -816,7 +823,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -826,6 +832,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -909,6 +916,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -947,7 +955,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -957,6 +964,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -1087,6 +1095,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_type": "SNS",
@@ -1216,6 +1225,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node18",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "event_type": "SQS",

--- a/integration_tests/snapshots/logs/process-input-traced_node20.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node20.log
@@ -48,6 +48,7 @@ START
           "_inferred_span.synchronicity": "sync",
           "http.method": "GET",
           "stage": "test",
+          "domain_name": "",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
@@ -81,6 +82,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
@@ -191,6 +193,7 @@ START
         "resource": "MODIFY someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -230,7 +233,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -240,6 +242,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
@@ -343,6 +346,7 @@ START
         "resource": "REMOVE someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -382,7 +386,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -392,6 +395,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
@@ -495,6 +499,7 @@ START
         "resource": "INSERT someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -534,7 +539,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -544,6 +548,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
@@ -647,6 +652,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -685,7 +691,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -695,6 +700,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -778,6 +784,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -816,7 +823,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -826,6 +832,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -909,6 +916,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -947,7 +955,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -957,6 +964,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -1087,6 +1095,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_type": "SNS",
@@ -1216,6 +1225,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node20",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "event_type": "SQS",

--- a/integration_tests/snapshots/logs/process-input-traced_node22.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node22.log
@@ -48,6 +48,7 @@ START
           "_inferred_span.synchronicity": "sync",
           "http.method": "GET",
           "stage": "test",
+          "domain_name": "",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
@@ -81,6 +82,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
@@ -191,6 +193,7 @@ START
         "resource": "MODIFY someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -230,7 +233,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -240,6 +242,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
@@ -343,6 +346,7 @@ START
         "resource": "REMOVE someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -382,7 +386,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -392,6 +395,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
@@ -495,6 +499,7 @@ START
         "resource": "INSERT someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -534,7 +539,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -544,6 +548,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
@@ -647,6 +652,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -685,7 +691,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -695,6 +700,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -778,6 +784,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -816,7 +823,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -826,6 +832,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -909,6 +916,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -947,7 +955,6 @@ START
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -957,6 +964,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "event_type": "S3",
@@ -1087,6 +1095,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_type": "SNS",
@@ -1216,6 +1225,7 @@ START
           "resource_names": "integration-tests-js-XXXX-process-input-traced_node22",
           "functionname": "integration-tests-js-XXXX-process-input-traced_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "event_type": "SQS",

--- a/integration_tests/snapshots/logs/status-code-500s_node18.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node18.log
@@ -54,6 +54,7 @@ START
           "_inferred_span.synchronicity": "sync",
           "http.method": "GET",
           "stage": "test",
+          "domain_name": "",
           "http.status_code": "500",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
@@ -87,6 +88,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
@@ -138,6 +140,7 @@ START
         "resource": "MODIFY someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -177,7 +180,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -187,6 +189,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -235,6 +238,7 @@ START
         "resource": "REMOVE someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -274,7 +278,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -284,6 +287,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -332,6 +336,7 @@ START
         "resource": "INSERT someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -371,7 +376,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -381,6 +385,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -429,6 +434,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -467,7 +473,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -477,6 +482,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -525,6 +531,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -563,7 +570,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -573,6 +579,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -621,6 +628,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -659,7 +667,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -669,6 +676,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -764,6 +772,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
@@ -858,6 +867,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node18",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node18",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",

--- a/integration_tests/snapshots/logs/status-code-500s_node20.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node20.log
@@ -54,6 +54,7 @@ START
           "_inferred_span.synchronicity": "sync",
           "http.method": "GET",
           "stage": "test",
+          "domain_name": "",
           "http.status_code": "500",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
@@ -87,6 +88,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
@@ -138,6 +140,7 @@ START
         "resource": "MODIFY someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -177,7 +180,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -187,6 +189,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -235,6 +238,7 @@ START
         "resource": "REMOVE someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -274,7 +278,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -284,6 +287,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -332,6 +336,7 @@ START
         "resource": "INSERT someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -371,7 +376,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -381,6 +385,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -429,6 +434,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -467,7 +473,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -477,6 +482,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -525,6 +531,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -563,7 +570,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -573,6 +579,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -621,6 +628,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -659,7 +667,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -669,6 +676,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -764,6 +772,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
@@ -858,6 +867,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node20",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node20",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",

--- a/integration_tests/snapshots/logs/status-code-500s_node22.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node22.log
@@ -54,6 +54,7 @@ START
           "_inferred_span.synchronicity": "sync",
           "http.method": "GET",
           "stage": "test",
+          "domain_name": "",
           "http.status_code": "500",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
@@ -87,6 +88,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
           "http.method": "GET",
@@ -138,6 +140,7 @@ START
         "resource": "MODIFY someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -177,7 +180,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -187,6 +189,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -235,6 +238,7 @@ START
         "resource": "REMOVE someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -274,7 +278,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -284,6 +287,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -332,6 +336,7 @@ START
         "resource": "INSERT someTableName",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -371,7 +376,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -381,6 +385,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "dynamodb",
           "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -429,6 +434,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -467,7 +473,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -477,6 +482,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -525,6 +531,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -563,7 +570,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -573,6 +579,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -621,6 +628,7 @@ START
         "resource": "my-bucket-name",
         "error": 0,
         "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -659,7 +667,6 @@ START
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
         "error": 0,
         "meta": {
-          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
           "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
           "runtime-id":"XXXX",
@@ -669,6 +676,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "s3",
           "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -764,6 +772,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sns",
           "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
@@ -858,6 +867,7 @@ START
           "resource_names": "integration-tests-js-XXXX-status-code-500s_node22",
           "functionname": "integration-tests-js-XXXX-status-code-500s_node22",
           "datadog_lambda":"XXXX",
+          "dd_trace": "",
           "function_trigger.event_source": "sqs",
           "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^20.12.10",
     "@types/promise-retry": "^1.1.3",
     "@types/shimmer": "^1.0.1",
-    "dd-trace": "^5.40.0",
+    "dd-trace": "^5.41.1",
     "jest": "^27.0.1",
     "mock-fs": "4.14.0",
     "nock": "13.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,10 +1144,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@datadog/libdatadog@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.4.0.tgz#aeeea02973f663b555ad9ac30c4015a31d561598"
-  integrity sha512-kGZfFVmQInzt6J4FFGrqMbrDvOxqwk3WqhAreS6n9b/De+iMVy/NMu3V7uKsY5zAvz+uQw0liDJm3ZDVH/MVVw==
+"@datadog/libdatadog@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.5.0.tgz#0ef2a2a76bb9505a0e7e5bc9be1415b467dbf368"
+  integrity sha512-YvLUVOhYVjJssm0f22/RnDQMc7ZZt/w1bA0nty1vvjyaDz5EWaHfWaaV4GYpCt5MRvnGjCBxIwwbRivmGseKeQ==
 
 "@datadog/native-appsec@8.4.0":
   version "8.4.0"
@@ -2403,7 +2403,12 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4, acorn@^8.8.2:
+acorn@^8.14.0:
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
+
+acorn@^8.2.4:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.13.0.tgz#2a30d670818ad16ddd6a35d3842dacec9e5d7ca3"
   integrity sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==
@@ -2816,12 +2821,12 @@ dc-polyfill@^0.1.3, dc-polyfill@^0.1.4:
   resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.6.tgz#c2940fa68ffb24a7bf127cc6cfdd15b39f0e7f02"
   integrity sha512-UV33cugmCC49a5uWAApM+6Ev9ZdvIUMTrtCO9fj96TPGOQiea54oeO3tiEVdVeo3J9N2UdJEmbS4zOkkEA35uQ==
 
-dd-trace@^5.40.0:
-  version "5.40.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.40.0.tgz#42633550bb015a8cf752587f8829fa0c7ae0be15"
-  integrity sha512-/UYVCcgpZ9LnnUvIJcNfd1Hj51i8HhqLOn9PCj5gK3wJUn6MY/ie/5da2ZaFtoK2DKQ9OZmFBITLV3+KDl4pjA==
+dd-trace@^5.41.1:
+  version "5.41.1"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.41.1.tgz#86c97ba2b0f22b7edb729e7feea32ee95a601ebf"
+  integrity sha512-rotpjjUBrqyqWBQMa3YlqeJ0v9Iq95XFdUMGtoTRKtth7OMNZXQ48/GSOi5Cdqi1Ci8+RhYAmusX/GCfZ24R7A==
   dependencies:
-    "@datadog/libdatadog" "^0.4.0"
+    "@datadog/libdatadog" "^0.5.0"
     "@datadog/native-appsec" "8.4.0"
     "@datadog/native-iast-rewriter" "2.8.0"
     "@datadog/native-iast-taint-tracking" "3.3.0"
@@ -2834,7 +2839,7 @@ dd-trace@^5.40.0:
     crypto-randomuuid "^1.0.0"
     dc-polyfill "^0.1.4"
     ignore "^5.2.4"
-    import-in-the-middle "1.11.2"
+    import-in-the-middle "1.13.1"
     istanbul-lib-coverage "3.2.0"
     jest-docblock "^29.7.0"
     koalas "^1.0.2"
@@ -3276,12 +3281,12 @@ ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-import-in-the-middle@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.2.tgz#dd848e72b63ca6cd7c34df8b8d97fc9baee6174f"
-  integrity sha512-gK6Rr6EykBcc6cVWRSBR5TWf8nn6hZMYSRYqCcHa0l0d1fPK7JSYo6+Mlmck76jIX9aL/IZ71c06U2VpFwl1zA==
+import-in-the-middle@1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz#789651f9e93dd902a5a306f499ab51eb72b03a12"
+  integrity sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==
   dependencies:
-    acorn "^8.8.2"
+    acorn "^8.14.0"
     acorn-import-attributes "^1.9.5"
     cjs-module-lexer "^1.2.2"
     module-details-from-path "^1.0.3"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Upgrades tracer to `v5.41.1`

### Motivation

Incident on past release

### Testing Guidelines

Checks

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
