### PR TITLE
Use correct SecretsManager region

### DIFF
--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -224,7 +224,7 @@ export class MetricsListener {
     if (config.apiKeySecretARN !== "") {
       try {
         const { SecretsManager } = await import("@aws-sdk/client-secrets-manager");
-        const secretRegion = config.apiKeySecretARN.split(':')[3];
+        const secretRegion = config.apiKeySecretARN.split(":")[3];
         const lambdaRegion = process.env.AWS_REGION;
         const isGovRegion = lambdaRegion !== undefined && lambdaRegion.startsWith("us-gov-");
         const secretsManager = new SecretsManager({

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -224,10 +224,12 @@ export class MetricsListener {
     if (config.apiKeySecretARN !== "") {
       try {
         const { SecretsManager } = await import("@aws-sdk/client-secrets-manager");
-        const region = process.env.AWS_REGION;
-        const isGovRegion = region !== undefined && region.startsWith("us-gov-");
+        const secretRegion = config.apiKeySecretARN.split(':')[3];
+        const lambdaRegion = process.env.AWS_REGION;
+        const isGovRegion = lambdaRegion !== undefined && lambdaRegion.startsWith("us-gov-");
         const secretsManager = new SecretsManager({
           useFipsEndpoint: isGovRegion,
+          region: secretRegion,
         });
         const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });
         return secret?.SecretString ?? "";


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Users could be storing their secret in SecretsManager in a different region than the currently running Lambda. This parses the arn for the correct region.

Before this change, users would get error: `Secrets Manager can't find the specified secret.`

### Motivation

Backports https://github.com/DataDog/datadog-lambda-extension/pull/604

### Testing Guidelines

Unit tests

- Tested manually with secret in same region, and it works
- Tested manually with secret in different region, and it works

### Additional Notes



### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
