### PR TITLE
Extract status code when returned as string

### DIFF
--- a/src/trace/trigger.spec.ts
+++ b/src/trace/trigger.spec.ts
@@ -129,6 +129,13 @@ describe("parseEventSource", () => {
     },
     {
       responseBody: {
+        statusCode: "201",
+        body: '"String status code case!"',
+      },
+      expectedStatusCode: "201",
+    },
+    {
+      responseBody: {
         statusCode: 404,
         body: '"NOT FOUND"',
       },

--- a/src/trace/trigger.ts
+++ b/src/trace/trigger.ts
@@ -395,6 +395,8 @@ export function extractHTTPStatusCodeTag(
     // Type check the statusCode if available
     if (typeof resultStatusCode === "number") {
       return resultStatusCode.toString();
+    } else if (typeof resultStatusCode === "string") {
+      return resultStatusCode;
     }
   } else {
     return "200";

--- a/src/trace/trigger.ts
+++ b/src/trace/trigger.ts
@@ -395,9 +395,8 @@ export function extractHTTPStatusCodeTag(
     // Type check the statusCode if available
     if (typeof resultStatusCode === "number") {
       return resultStatusCode.toString();
-    } else if (typeof resultStatusCode === "string") {
-      return resultStatusCode;
     }
+    return resultStatusCode.toString();
   } else {
     return "200";
   }

--- a/src/trace/trigger.ts
+++ b/src/trace/trigger.ts
@@ -392,10 +392,6 @@ export function extractHTTPStatusCodeTag(
   if (result === undefined && !isResponseStreamFunction) {
     return "502";
   } else if (resultStatusCode) {
-    // Type check the statusCode if available
-    if (typeof resultStatusCode === "number") {
-      return resultStatusCode.toString();
-    }
     return resultStatusCode.toString();
   } else {
     return "200";


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Handles case where the status code is a string instead of a number.
We extract this status code in `extractHTTPStatusCodeTag()` 

### Motivation

https://github.com/DataDog/datadog-lambda-js/issues/641

### Testing Guidelines

Manual+unit

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
