### PR TITLE
Sles 2151 fix race condition flush

### DIFF
--- a/src/metrics/processor.ts
+++ b/src/metrics/processor.ts
@@ -80,7 +80,7 @@ export class Processor {
           const metricsReceivedWhileSending = this.batcher.toAPIMetrics();
           if (metricsReceivedWhileSending.length > 0) {
             logWarning(
-              `Failed to send metrics to Datadog, retrying at next interval. ${metricsReceivedWhileSending.length} netrics received will be lost`,
+              `Failed to send metrics to Datadog, retrying at next interval. ${metricsReceivedWhileSending.length} metrics received will be lost`,
             );
           }
           this.batcher = oldBatcher;

--- a/src/metrics/processor.ts
+++ b/src/metrics/processor.ts
@@ -1,6 +1,6 @@
 import promiseRetry from "promise-retry";
 
-import { logError, Timer } from "../utils";
+import { logError, logWarning, Timer } from "../utils";
 import { Client } from "./api";
 import { Batcher } from "./batcher";
 import { Metric } from "./model";
@@ -77,6 +77,10 @@ export class Processor {
       } catch {
         // Failed to send metrics, keep the old batch alive if retrying is enabled
         if (this.shouldRetryOnFail) {
+          const metricsReceivedWhileSending = this.batcher.toAPIMetrics();
+          if (metricsReceivedWhileSending.length > 0) {
+            logWarning(`Failed to send metrics to Datadog, retrying at next interval. ${metricsReceivedWhileSending.length} netrics received will be lost`);
+          }
           this.batcher = oldBatcher;
         }
       }

--- a/src/metrics/processor.ts
+++ b/src/metrics/processor.ts
@@ -79,7 +79,9 @@ export class Processor {
         if (this.shouldRetryOnFail) {
           const metricsReceivedWhileSending = this.batcher.toAPIMetrics();
           if (metricsReceivedWhileSending.length > 0) {
-            logWarning(`Failed to send metrics to Datadog, retrying at next interval. ${metricsReceivedWhileSending.length} netrics received will be lost`);
+            logWarning(
+              `Failed to send metrics to Datadog, retrying at next interval. ${metricsReceivedWhileSending.length} netrics received will be lost`,
+            );
           }
           this.batcher = oldBatcher;
         }


### PR DESCRIPTION
- add warning in case a failed send will drop metrics received during the try
- do not create one promise per metric. This would let the process to wait for only one promise and avoid missing metrics https://github.com/DataDog/datadog-lambda-js/issues/638