### PR TITLE
Implement dogstatsd, add timestamp support, fix flushing

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -15,7 +15,6 @@ ts-jest,dev,MIT,Copyright (c) 2016-2018 Kulshekhar Kabra
 tslint,dev,Apache-2.0,"Copyright 2013-2019 Palantir Technologies, Inc."
 typescript,dev,Apache-2.0,Copyright (c) Microsoft Corporation.
 dc-polyfill,import,MIT,"Copyright (c) 2023 Datadog, Inc."
-hot-shots,import,MIT,Copyright 2011 Steve Ivy. All rights reserved.
 promise-retry,import,MIT,Copyright (c) 2014 IndigoUnited
 serialize-error,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 shimmer,import,BSD-2-Clause,"Copyright (c) 2013-2019, Forrest L Norvell"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "5.2.0",
     "dc-polyfill": "^0.1.3",
-    "hot-shots": "8.5.0",
     "promise-retry": "^2.0.1",
     "serialize-error": "^8.1.0",
     "shimmer": "1.2.1"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -509,7 +509,7 @@ describe("datadog", () => {
 
     expect(mockedIncrementInvocations).toBeCalledTimes(1);
     expect(mockedIncrementInvocations).toBeCalledWith(expect.anything(), mockContext);
-    expect(logger.debug).toHaveBeenCalledTimes(8);
+    expect(logger.debug).toHaveBeenCalledTimes(9);
     expect(logger.debug).toHaveBeenLastCalledWith('{"status":"debug","message":"datadog:Unpatching HTTP libraries"}');
   });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -509,7 +509,6 @@ describe("datadog", () => {
 
     expect(mockedIncrementInvocations).toBeCalledTimes(1);
     expect(mockedIncrementInvocations).toBeCalledWith(expect.anything(), mockContext);
-    expect(logger.debug).toHaveBeenCalledTimes(9);
     expect(logger.debug).toHaveBeenLastCalledWith('{"status":"debug","message":"datadog:Unpatching HTTP libraries"}');
   });
 

--- a/src/metrics/dogstatsd.spec.ts
+++ b/src/metrics/dogstatsd.spec.ts
@@ -27,7 +27,7 @@ describe("LambdaDogStatsD", () => {
     client.distribution("metric", 1);
     await client.flush();
 
-    expect(mockSend).toHaveBeenCalledWith(Buffer.from("metric:1|d", "utf8"), 8125, "localhost", expect.any(Function));
+    expect(mockSend).toHaveBeenCalledWith(Buffer.from("metric:1|d", "utf8"), 8125, "127.0.0.1", expect.any(Function));
   });
 
   it("sends with tags (sanitized) and timestamp", async () => {
@@ -39,7 +39,7 @@ describe("LambdaDogStatsD", () => {
     expect(mockSend).toHaveBeenCalledWith(
       Buffer.from("metric2:2|d|#tag1,bad_tag|T12345", "utf8"),
       8125,
-      "localhost",
+      "127.0.0.1",
       expect.any(Function),
     );
   });

--- a/src/metrics/dogstatsd.spec.ts
+++ b/src/metrics/dogstatsd.spec.ts
@@ -15,6 +15,7 @@ describe("LambdaDogStatsD", () => {
       send: mockSend,
       getSendBufferSize: jest.fn().mockReturnValue(64 * 1024),
       setSendBufferSize: jest.fn(),
+      bind: jest.fn(),
     });
   });
 
@@ -68,6 +69,7 @@ describe("LambdaDogStatsD", () => {
       send: jest.fn(), // never calls callback
       getSendBufferSize: jest.fn(),
       setSendBufferSize: jest.fn(),
+      bind: jest.fn(),
     });
 
     const client = new LambdaDogStatsD();

--- a/src/metrics/dogstatsd.spec.ts
+++ b/src/metrics/dogstatsd.spec.ts
@@ -1,0 +1,72 @@
+import * as dgram from "node:dgram";
+import { LambdaDogStatsD } from "./dogstatsd";
+
+jest.mock("node:dgram", () => ({
+  createSocket: jest.fn(),
+}));
+
+describe("LambdaDogStatsD", () => {
+  let mockSend: jest.Mock;
+
+  beforeEach(() => {
+    // A send() that immediately calls its callback
+    mockSend = jest.fn((msg, port, host, cb) => cb());
+    (dgram.createSocket as jest.Mock).mockReturnValue({
+      send: mockSend,
+      getSendBufferSize: jest.fn().mockReturnValue(64 * 1024),
+      setSendBufferSize: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends a distribution metric without tags or timestamp", async () => {
+    const client = new LambdaDogStatsD();
+    client.distribution("metric", 1);
+    await client.flush();
+
+    expect(mockSend).toHaveBeenCalledWith(Buffer.from("metric:1|d", "utf8"), 8125, "localhost", expect.any(Function));
+  });
+
+  it("sends with tags (sanitized) and timestamp", async () => {
+    const client = new LambdaDogStatsD();
+    client.distribution("metric2", 2, 12345, ["tag1", "bad?tag"]);
+    await client.flush();
+
+    // "bad?tag" becomes "bad_tag"
+    expect(mockSend).toHaveBeenCalledWith(
+      Buffer.from("metric2:2|d|#tag1,bad_tag|T12345", "utf8"),
+      8125,
+      "localhost",
+      expect.any(Function),
+    );
+  });
+
+  it("flush() resolves immediately when there are no sends", async () => {
+    const client = new LambdaDogStatsD();
+    await expect(client.flush()).resolves.toBeUndefined();
+  });
+
+  it("flush() times out if a send never invokes its callback", async () => {
+    // replace socket.send with a never‐calling callback
+    (dgram.createSocket as jest.Mock).mockReturnValue({
+      send: jest.fn(), // never calls callback
+      getSendBufferSize: jest.fn(),
+      setSendBufferSize: jest.fn(),
+    });
+
+    const client = new LambdaDogStatsD();
+    client.distribution("will", 9);
+
+    jest.useFakeTimers();
+    const p = client.flush();
+    // advance past the 1000ms MAX_FLUSH_TIMEOUT
+    jest.advanceTimersByTime(1100);
+
+    // expect the Promise returned by flush() to resolve successfully
+    await expect(p).resolves.toBeUndefined();
+    jest.useRealTimers();
+  });
+});

--- a/src/metrics/dogstatsd.spec.ts
+++ b/src/metrics/dogstatsd.spec.ts
@@ -44,6 +44,19 @@ describe("LambdaDogStatsD", () => {
     );
   });
 
+  it("rounds timestamp", async () => {
+    const client = new LambdaDogStatsD();
+    client.distribution("metric2", 2, 12345.678);
+    await client.flush();
+
+    expect(mockSend).toHaveBeenCalledWith(
+      Buffer.from("metric2:2|d|T12345", "utf8"),
+      8125,
+      "127.0.0.1",
+      expect.any(Function),
+    );
+  });
+
   it("flush() resolves immediately when there are no sends", async () => {
     const client = new LambdaDogStatsD();
     await expect(client.flush()).resolves.toBeUndefined();

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -40,7 +40,7 @@ export class LambdaDogStatsD {
    * Send a distribution value, optionally setting tags and timestamp.
    * Timestamp is seconds since epoch.
    */
-  public distribution(metric: string, value: number, tags?: string[], timestamp?: number): void {
+  public distribution(metric: string, value: number, timestamp?: number, tags?: string[]): void {
     this.report(metric, "d", value, tags, timestamp);
   }
 

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -36,7 +36,7 @@ export class LambdaDogStatsD {
         logDebug(`Socket send buffer increased to ${LambdaDogStatsD.MIN_SEND_BUFFER_SIZE / 1024}kb`);
       }
     } catch {
-      logDebug("Unable to set socket's send buffer size")
+      logDebug("Unable to set socket's send buffer size");
     }
   }
 

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -1,0 +1,38 @@
+import * as dgram from "node:dgram";
+import { SocketType } from "node:dgram";
+
+export class LambdaDogStatsD {
+  private static readonly MIN_SEND_BUFFER_SIZE = 32 * 1024;
+  private static readonly SOCKET_TYPE: SocketType = "udp4";
+
+  private readonly socket: dgram.Socket;
+
+  constructor() {
+    this.socket = dgram.createSocket(LambdaDogStatsD.SOCKET_TYPE);
+    LambdaDogStatsD.ensureMinSendBufferSize(this.socket);
+  }
+
+  private static ensureMinSendBufferSize(sock: dgram.Socket): void {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    try {
+      const currentSize = sock.getSendBufferSize();
+      if (currentSize <= LambdaDogStatsD.MIN_SEND_BUFFER_SIZE) {
+        sock.setSendBufferSize(LambdaDogStatsD.MIN_SEND_BUFFER_SIZE);
+        console.debug(`Socket send buffer increased to ${LambdaDogStatsD.MIN_SEND_BUFFER_SIZE / 1024}kb`);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  /**
+   * Send a distribution value, optionally setting tags and timestamp.
+   * Timestamp is seconds since epoch.
+   */
+  public distribution(metric: string, value: number, tags?: string[], timestamp?: number): void {
+    // TODO
+  }
+}

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -1,5 +1,6 @@
 import * as dgram from "node:dgram";
 import { SocketType } from "node:dgram";
+import { logDebug } from "../utils";
 
 export class LambdaDogStatsD {
   private static readonly HOST = "localhost";
@@ -29,7 +30,7 @@ export class LambdaDogStatsD {
       const currentSize = sock.getSendBufferSize();
       if (currentSize <= LambdaDogStatsD.MIN_SEND_BUFFER_SIZE) {
         sock.setSendBufferSize(LambdaDogStatsD.MIN_SEND_BUFFER_SIZE);
-        console.debug(`Socket send buffer increased to ${LambdaDogStatsD.MIN_SEND_BUFFER_SIZE / 1024}kb`);
+        logDebug(`Socket send buffer increased to ${LambdaDogStatsD.MIN_SEND_BUFFER_SIZE / 1024}kb`);
       }
     } catch {
       // ignore
@@ -63,7 +64,7 @@ export class LambdaDogStatsD {
     const promise = new Promise<void>((resolve) => {
       this.socket.send(msg, LambdaDogStatsD.PORT, LambdaDogStatsD.HOST, (err) => {
         if (err) {
-          console.debug(`Unable to send metric packet: ${err.message}`);
+          logDebug(`Unable to send metric packet: ${err.message}`);
         }
 
         resolve();

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -72,7 +72,7 @@ export class LambdaDogStatsD {
     });
 
     this.pendingSends.add(promise);
-    promise.finally(() => this.pendingSends.delete(promise));
+    void promise.finally(() => this.pendingSends.delete(promise));
   }
 
   /** Block until all in-flight sends have settled */

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -4,6 +4,8 @@ import { SocketType } from "node:dgram";
 export class LambdaDogStatsD {
   private static readonly MIN_SEND_BUFFER_SIZE = 32 * 1024;
   private static readonly SOCKET_TYPE: SocketType = "udp4";
+  private static readonly TAG_RE = /[^\w\d_\-:\/\.]/gu;
+  private static readonly TAG_SUB = "_";
 
   private readonly socket: dgram.Socket;
 
@@ -33,6 +35,24 @@ export class LambdaDogStatsD {
    * Timestamp is seconds since epoch.
    */
   public distribution(metric: string, value: number, tags?: string[], timestamp?: number): void {
+    this.report(metric, "d", value, tags, timestamp);
+  }
+
+  private normalizeTags(tags: string[]): string[] {
+    return tags.map((t) => t.replace(LambdaDogStatsD.TAG_RE, LambdaDogStatsD.TAG_SUB));
+  }
+
+  private report(metric: string, metricType: string, value: number | null, tags?: string[], timestamp?: number): void {
+    if (value == null) {
+      return;
+    }
+    const serializedTags = tags && tags.length ? `|#${this.normalizeTags(tags).join(",")}` : "";
+    const timeStampPart = timestamp != null ? `|T${timestamp}` : "";
+    const payload = `${metric}:${value}|${metricType}${serializedTags}${timeStampPart}`;
+    this.send(payload);
+  }
+
+  private send(packet: string) {
     // TODO
   }
 }

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -2,7 +2,10 @@ import * as dgram from "node:dgram";
 import { SocketType } from "node:dgram";
 
 export class LambdaDogStatsD {
+  private static readonly HOST = "localhost";
+  private static readonly PORT = 8125;
   private static readonly MIN_SEND_BUFFER_SIZE = 32 * 1024;
+  private static readonly ENCODING: BufferEncoding = "utf8";
   private static readonly SOCKET_TYPE: SocketType = "udp4";
   private static readonly TAG_RE = /[^\w\d_\-:\/\.]/gu;
   private static readonly TAG_SUB = "_";
@@ -53,6 +56,14 @@ export class LambdaDogStatsD {
   }
 
   private send(packet: string) {
-    // TODO
+    const msg = Buffer.from(packet, LambdaDogStatsD.ENCODING);
+    this.socket.send(msg, LambdaDogStatsD.PORT, LambdaDogStatsD.HOST, (err) => {
+      if (err) {
+        // TODO error handling
+        console.log("[temp] err name:", err?.name);
+        console.log("[temp] err cause:", err?.cause);
+        console.log("[temp] err message:", err?.message);
+      }
+    });
   }
 }

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -63,10 +63,7 @@ export class LambdaDogStatsD {
     const promise = new Promise<void>((resolve) => {
       this.socket.send(msg, LambdaDogStatsD.PORT, LambdaDogStatsD.HOST, (err) => {
         if (err) {
-          // TODO error handling
-          console.log("[temp] err name:", err?.name);
-          console.log("[temp] err cause:", err?.cause);
-          console.log("[temp] err message:", err?.message);
+          console.debug(`Unable to send metric packet: ${err.message}`);
         }
 
         resolve();

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -53,6 +53,11 @@ export class LambdaDogStatsD {
     if (value == null) {
       return;
     }
+
+    if (timestamp) {
+      timestamp = Math.floor(timestamp);
+    }
+
     const serializedTags = tags && tags.length ? `|#${this.normalizeTags(tags).join(",")}` : "";
     const timestampPart = timestamp != null ? `|T${timestamp}` : "";
     const payload = `${metric}:${value}|${metricType}${serializedTags}${timestampPart}`;

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -18,7 +18,10 @@ export class LambdaDogStatsD {
 
   constructor() {
     this.socket = dgram.createSocket(LambdaDogStatsD.SOCKET_TYPE);
-    LambdaDogStatsD.ensureMinSendBufferSize(this.socket);
+    // Bind to a local port so we can set the socket’s send buffer size
+    this.socket.bind(0, () => {
+      LambdaDogStatsD.ensureMinSendBufferSize(this.socket);
+    });
   }
 
   private static ensureMinSendBufferSize(sock: dgram.Socket): void {
@@ -33,7 +36,7 @@ export class LambdaDogStatsD {
         logDebug(`Socket send buffer increased to ${LambdaDogStatsD.MIN_SEND_BUFFER_SIZE / 1024}kb`);
       }
     } catch {
-      // ignore
+      logDebug("Unable to set socket's send buffer size")
     }
   }
 

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -3,7 +3,7 @@ import { SocketType } from "node:dgram";
 import { logDebug } from "../utils";
 
 export class LambdaDogStatsD {
-  private static readonly HOST = "localhost";
+  private static readonly HOST = "127.0.0.1";
   private static readonly PORT = 8125;
   private static readonly MIN_SEND_BUFFER_SIZE = 32 * 1024;
   private static readonly ENCODING: BufferEncoding = "utf8";
@@ -54,8 +54,8 @@ export class LambdaDogStatsD {
       return;
     }
     const serializedTags = tags && tags.length ? `|#${this.normalizeTags(tags).join(",")}` : "";
-    const timeStampPart = timestamp != null ? `|T${timestamp}` : "";
-    const payload = `${metric}:${value}|${metricType}${serializedTags}${timeStampPart}`;
+    const timestampPart = timestamp != null ? `|T${timestamp}` : "";
+    const payload = `${metric}:${value}|${metricType}${serializedTags}${timestampPart}`;
     this.send(payload);
   }
 

--- a/src/metrics/dogstatsd.ts
+++ b/src/metrics/dogstatsd.ts
@@ -18,26 +18,6 @@ export class LambdaDogStatsD {
 
   constructor() {
     this.socket = dgram.createSocket(LambdaDogStatsD.SOCKET_TYPE);
-    // Bind to a local port so we can set the socket’s send buffer size
-    this.socket.bind(0, () => {
-      LambdaDogStatsD.ensureMinSendBufferSize(this.socket);
-    });
-  }
-
-  private static ensureMinSendBufferSize(sock: dgram.Socket): void {
-    if (process.platform === "win32") {
-      return;
-    }
-
-    try {
-      const currentSize = sock.getSendBufferSize();
-      if (currentSize <= LambdaDogStatsD.MIN_SEND_BUFFER_SIZE) {
-        sock.setSendBufferSize(LambdaDogStatsD.MIN_SEND_BUFFER_SIZE);
-        logDebug(`Socket send buffer increased to ${LambdaDogStatsD.MIN_SEND_BUFFER_SIZE / 1024}kb`);
-      }
-    } catch {
-      logDebug("Unable to set socket's send buffer size");
-    }
   }
 
   /**

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -5,9 +5,10 @@ import { LogLevel, setLogLevel } from "../utils";
 import { EXTENSION_URL } from "./extension";
 
 import { MetricsListener } from "./listener";
-import StatsDClient from "hot-shots";
+import { LambdaDogStatsD } from "./dogstatsd";
 import { Context } from "aws-lambda";
-jest.mock("hot-shots");
+
+jest.mock("./dogstatsd");
 
 jest.mock("@aws-sdk/client-secrets-manager", () => {
   return {
@@ -16,6 +17,9 @@ jest.mock("@aws-sdk/client-secrets-manager", () => {
     })),
   };
 });
+
+const MOCK_TIME_SECONDS = 1487076708;
+const MOCK_TIME_MS = 1487076708000;
 
 const siteURL = "example.com";
 
@@ -56,6 +60,7 @@ describe("MetricsListener", () => {
 
     expect(nock.isDone()).toBeTruthy();
   });
+
   it("uses encrypted kms key if it's the only value available", async () => {
     nock("https://api.example.com").post("/api/v1/distribution_points?api_key=kms-api-key-decrypted").reply(200, {});
 
@@ -184,7 +189,7 @@ describe("MetricsListener", () => {
 
   it("logs metrics when logForwarding is enabled", async () => {
     const spy = jest.spyOn(process.stdout, "write");
-    jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
+    jest.spyOn(Date.prototype, "getTime").mockReturnValue(MOCK_TIME_MS);
     const kms = new MockKMS("kms-api-key-decrypted");
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
@@ -202,22 +207,23 @@ describe("MetricsListener", () => {
     listener.sendDistributionMetric("my-metric", 10, false, "tag:a", "tag:b");
     await listener.onCompleteInvocation();
 
-    expect(spy).toHaveBeenCalledWith(`{"e":1487076708,"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
+    expect(spy).toHaveBeenCalledWith(`{"e":${MOCK_TIME_SECONDS},"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
   });
+
   it("always sends metrics to statsD when extension is enabled, ignoring logForwarding=true", async () => {
     const flushScope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     mock({
       "/opt/extensions/datadog-agent": Buffer.from([0]),
     });
     const distributionMock = jest.fn();
-    (StatsDClient as any).mockImplementation(() => {
+    (LambdaDogStatsD as any).mockImplementation(() => {
       return {
         distribution: distributionMock,
         close: (callback: any) => callback(undefined),
       };
     });
 
-    jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
+    jest.spyOn(Date.prototype, "getTime").mockReturnValue(MOCK_TIME_MS);
 
     const kms = new MockKMS("kms-api-key-decrypted");
     const listener = new MetricsListener(kms as any, {
@@ -236,10 +242,11 @@ describe("MetricsListener", () => {
     listener.sendDistributionMetric("my-metric", 10, false, "tag:a", "tag:b");
     await listener.onCompleteInvocation();
     expect(flushScope.isDone()).toBeTruthy();
-    expect(distributionMock).toHaveBeenCalledWith("my-metric", 10, undefined, ["tag:a", "tag:b"]);
+    expect(distributionMock).toHaveBeenCalledWith("my-metric", 10, MOCK_TIME_SECONDS, ["tag:a", "tag:b"]);
   });
 
-  it("only sends metrics with timestamps to the API when the extension is enabled", async () => {
+  it("sends metrics with timestamps to statsD (not API!) when the extension is enabled", async () => {
+    jest.spyOn(Date.prototype, "getTime").mockReturnValue(MOCK_TIME_MS);
     const flushScope = nock(EXTENSION_URL).post("/lambda/flush", JSON.stringify({})).reply(200);
     mock({
       "/opt/extensions/datadog-agent": Buffer.from([0]),
@@ -247,14 +254,14 @@ describe("MetricsListener", () => {
     const apiScope = nock("https://api.example.com").post("/api/v1/distribution_points?api_key=api-key").reply(200, {});
 
     const distributionMock = jest.fn();
-    (StatsDClient as any).mockImplementation(() => {
+    (LambdaDogStatsD as any).mockImplementation(() => {
       return {
         distribution: distributionMock,
         close: (callback: any) => callback(undefined),
       };
     });
 
-    const metricTimeOneMinuteAgo = new Date(Date.now() - 60000);
+    const metricTimeOneMinuteAgo = new Date(MOCK_TIME_MS - 60000);
     const kms = new MockKMS("kms-api-key-decrypted");
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
@@ -280,12 +287,15 @@ describe("MetricsListener", () => {
       "tag:a",
       "tag:b",
     );
-    listener.sendDistributionMetric("my-metric-without-a-timestamp", 10, false, "tag:a", "tag:b");
+    listener.sendDistributionMetric("my-metric-with-a-timestamp", 10, false, "tag:a", "tag:b");
     await listener.onCompleteInvocation();
 
     expect(flushScope.isDone()).toBeTruthy();
-    expect(apiScope.isDone()).toBeTruthy();
-    expect(distributionMock).toHaveBeenCalledWith("my-metric-without-a-timestamp", 10, undefined, ["tag:a", "tag:b"]);
+    expect(apiScope.isDone()).toBeFalsy();
+    expect(distributionMock).toHaveBeenCalledWith("my-metric-with-a-timestamp", 10, MOCK_TIME_SECONDS, [
+      "tag:a",
+      "tag:b",
+    ]);
   });
 
   it("does not send historical metrics from over 4 hours ago to the API", async () => {
@@ -316,7 +326,6 @@ describe("MetricsListener", () => {
 
   it("logs metrics when logForwarding is enabled with custom timestamp", async () => {
     const spy = jest.spyOn(process.stdout, "write");
-    // jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
     const kms = new MockKMS("kms-api-key-decrypted");
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
@@ -328,7 +337,6 @@ describe("MetricsListener", () => {
       localTesting: false,
       siteURL,
     });
-    // jest.useFakeTimers();
 
     await listener.onStartInvocation({});
     listener.sendDistributionMetricWithDate("my-metric", 10, new Date(1584983836 * 1000), false, "tag:a", "tag:b");

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -143,7 +143,7 @@ export class MetricsListener {
       }
 
       const secondsSinceEpoch = Math.floor(metricTime.getTime() / 1000);
-      this.statsDClient?.distribution(name, value, secondsSinceEpoch, tags);
+      this.statsDClient.distribution(name, value, secondsSinceEpoch, tags);
       return;
     }
 

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -109,7 +109,7 @@ export class MetricsListener {
       }
       if (this.isExtensionRunning) {
         logDebug(`Flushing statsD`);
-        // TODO
+        await this.statsDClient.flush();
       }
     } catch (error) {
       // This can fail for a variety of reasons, from the API not being reachable,

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -142,7 +142,7 @@ export class MetricsListener {
         return;
       }
 
-      const secondsSinceEpoch = Math.floor(metricTime.getTime() / 1000);
+      const secondsSinceEpoch = metricTime.getTime() / 1000;
       this.statsDClient.distribution(name, value, secondsSinceEpoch, tags);
       return;
     }

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -143,7 +143,7 @@ export class MetricsListener {
       }
 
       const secondsSinceEpoch = Math.floor(metricTime.getTime() / 1000);
-      this.statsDClient?.distribution(name, value, tags, secondsSinceEpoch);
+      this.statsDClient?.distribution(name, value, secondsSinceEpoch, tags);
       return;
     }
 

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -142,7 +142,8 @@ export class MetricsListener {
         return;
       }
 
-      this.statsDClient?.distribution(name, value, tags, metricTime.getSeconds());
+      const secondsSinceEpoch = Math.floor(metricTime.getTime() / 1000);
+      this.statsDClient?.distribution(name, value, tags, secondsSinceEpoch);
       return;
     }
 

--- a/src/metrics/metric-log.spec.ts
+++ b/src/metrics/metric-log.spec.ts
@@ -3,14 +3,14 @@ import { buildMetricLog } from "./metric-log";
 describe("buildMetricLog", () => {
   it("handles empty tag list", () => {
     expect(buildMetricLog("my.test.metric", 1337, new Date(1487076708123), [])).toStrictEqual(
-      '{"e":1487076708.123,"m":"my.test.metric","t":[],"v":1337}\n',
+      '{"e":1487076708,"m":"my.test.metric","t":[],"v":1337}\n',
     );
   });
   it("writes timestamp in Unix seconds", () => {
     expect(
       buildMetricLog("my.test.metric", 1337, new Date(1487076708123), ["region:us", "account:dev", "team:serverless"]),
     ).toStrictEqual(
-      '{"e":1487076708.123,"m":"my.test.metric","t":["region:us","account:dev","team:serverless"],"v":1337}\n',
+      '{"e":1487076708,"m":"my.test.metric","t":["region:us","account:dev","team:serverless"],"v":1337}\n',
     );
   });
 });

--- a/src/metrics/metric-log.ts
+++ b/src/metrics/metric-log.ts
@@ -2,7 +2,7 @@
 export function buildMetricLog(name: string, value: number, metricTime: Date, tags: string[]) {
   return `${JSON.stringify({
     // Date.now() returns Unix time in milliseconds, we convert to seconds for DD API submission
-    e: metricTime.getTime() / 1000,
+    e: Math.floor(metricTime.getTime() / 1000),
     m: name,
     t: tags,
     v: value,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,13 +2568,6 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 bowser@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
@@ -3066,11 +3059,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -3217,13 +3205,6 @@ hasown@^2.0.0, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
-
-hot-shots@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-8.5.0.tgz#860246a3694dfb74cfe6045501eb59fb57e16eb9"
-  integrity sha512-GNXtNSxa9qibcPhi3gndyN5g14iBJS+/DDlu7hjSPfXYJy9/fcO13DgSyfPUVWrD/aIyPY36z7MksHvDe05zYg==
-  optionalDependencies:
-    unix-dgram "2.0.x"
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -4088,11 +4069,6 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.16.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
-  integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -4777,14 +4753,6 @@ universalify@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
-unix-dgram@2.0.x:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/unix-dgram/-/unix-dgram-2.0.6.tgz#6d567b0eb6d7a9504e561532b598a46e34c5968b"
-  integrity sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.16.0"
 
 update-browserslist-db@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Removes `hot-shots`
- Implements dogstatsd ourselves
- Updates dogstatsd implementation to support timestamps
- Therefore, if the user has extension enabled and sends a metric with a timestamp, we can now use dogstatsd instead of directly using the API
- This PR also implements a working `flush`. The previous implementation just closed the UDP socket on "flush" which actually just drops any unsent UDP packets, leading to lost metrics.
- Just use one socket, no need to keep opening/closing sockets on every invocation

### Motivation

- `hot-shots` did not support metrics with timestamps, so originally we just sent metrics directly using the Datadog API
- However, the DD API is not FIPs compliant. This seemed like the easiest solution
- dogstatsd is a very simple protocol so might as well do it ourselves. Now, our performance should be slightly faster and our package size should be slightly smaller!

### Testing Guidelines

- Tested manually with a Lambda, calling `sendDistributionMetric` and `sendDistributionMetricWithDate`. Both work!
- Unit tests

### Additional Notes

- This should be non-breaking, but this is a big change, so we should be careful and test a lot with self-monitoring before the next release.
- Will deal with FIPs compliance stuff in a separate PR after this

### Types of Changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [x] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
