### PR TITLE
Fix SignatureDoesNotMatch error when SecretsManager enabled

### DIFF
--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -63,18 +63,24 @@ export interface MetricsConfig {
 
 export class MetricsListener {
   private currentProcessor?: Promise<any>;
-  private apiKey: Promise<string>;
+  private apiKey: Promise<string> | undefined;
   private statsDClient: LambdaDogStatsD;
   private isExtensionRunning?: boolean = undefined;
   private globalTags?: string[] = [];
 
   constructor(private kmsClient: KMSService, private config: MetricsConfig) {
-    this.apiKey = this.getAPIKey(config);
     this.config = config;
     this.statsDClient = new LambdaDogStatsD();
   }
 
   public async onStartInvocation(_: any, context?: Context) {
+    // We get the API key in onStartInvocation rather than in the constructor because in busy functions,
+    // initialization may occur more than 5 minutes before the first invocation (due to proactive initialization),
+    // resulting in AWS errors: https://github.com/aws/aws-sdk-js-v3/issues/5192#issuecomment-2073243617
+    if (!this.apiKey) {
+      this.apiKey = this.getAPIKey(this.config);
+    }
+
     if (this.isExtensionRunning === undefined) {
       this.isExtensionRunning = await isExtensionRunning();
       logDebug(`Extension present: ${this.isExtensionRunning}`);

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -63,7 +63,7 @@ export interface MetricsConfig {
 
 export class MetricsListener {
   private currentProcessor?: Promise<any>;
-  private apiKey: Promise<string> | undefined;
+  private apiKey?: Promise<string>;
   private statsDClient: LambdaDogStatsD;
   private isExtensionRunning?: boolean = undefined;
   private globalTags?: string[] = [];


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- In https://github.com/DataDog/datadog-lambda-js/pull/616, we upgraded aws-sdk to v3 for SecretsManager
- In Lambda, v3 of SecretsManager can cause a SignatureDoesNotMatch error in Lambda: https://github.com/aws/aws-sdk-js-v3/issues/5192#issuecomment-2073243617
- Due to proactive initialization, a busy Lambda might have a container initialize more than 5 minutes before the first invocation
- Originally, we were creating the SecretsManager client during initialization. Since `getAPIKey` is an async function, it may get paused after importing SecretsManager and may not continue with the `getSecretValue` call until the first invocation
- If there's a >5 min gap, we get errors
- To resolve this, we can just get the API key during the first invocation

```typescript
    if (config.apiKeySecretARN !== "") {
      try {
        // Runs on init, which may be a proactive init.
        const { SecretsManager } = await import("@aws-sdk/client-secrets-manager");

        // Runs after the promise resolves, which may be during init or may be later (on the first invocation)
        const secretRegion = config.apiKeySecretARN.split(":")[3];
        const secretsManager = new SecretsManager({
          useFipsEndpoint: FIPS_MODE_ENABLED,
          region: secretRegion,
        });

        // May not run until the first invocation, possibly leading to a >5 min gap
        const secret = await secretsManager.getSecretValue({ SecretId: config.apiKeySecretARN });
        return secret?.SecretString ?? "";
      } catch (error) {
        logError("couldn't get secrets manager api key", error as Error);
      }
    }
```

### Motivation

Multiple ZenDesk tickets opened by customers
https://datadoghq.atlassian.net/browse/SVLS-6813

### Testing Guidelines

This is a really rare edge case so I haven't been able to reproduce it, but I did manually verify that none of these changes breaks getting the API key from SecretsManager. Traces and metrics still get sent to Datadog successfully

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
