### PR TITLE
chore: Use GitHub App for update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -3,6 +3,7 @@ name: update-deps
 on:
   schedule:
     - cron: "0 10 * * *" # Run at 10 am every day
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -7,10 +7,19 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    environment:
+      name: protected-main-env
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v2
         with:
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Makes the upgrade workflow use GitHub Apps to get temporary tokens instead of using a long-lived SSH key.

### Motivation

<!--- What inspired you to submit this pull request? --->

This workflow is broken, probably because the SSH key no longer works. Instead of creating a new SSH key, we use a GitHub App, which generates short-lived tokens and is more secure than SSH key.

### Testing Guidelines

<!--- How did you test this pull request? --->

Will test the workflow after this PR is merged to `main` because I can't manually trigger it right now.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)

Jira: https://datadoghq.atlassian.net/browse/SVLS-6929