### PR TITLE
(fix): timeouts for sync handlers returning non-undefined values; fix ESM return values

### DIFF
--- a/integration_tests/snapshots/logs/esm_node18.log
+++ b/integration_tests/snapshots/logs/esm_node18.log
@@ -15,6 +15,90 @@ START
   ],
   "v": 1
 }
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.apigateway",
+        "resource": "GET /{proxy+}",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedApiGatewayServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.apigateway",
+          "http.url": "https://undefined",
+          "resource_names": "GET /{proxy+}",
+          "request_id":"XXXX",
+          "apiid":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "sync",
+          "http.method": "GET",
+          "stage": "test",
+          "domain_name": "",
+          "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedApiGatewayServiceName",
+        "type": "http"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
+          "http.method": "GET",
+          "http.route": "/{proxy+}",
+          "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 START
 {
@@ -32,22 +116,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node18",
-    "resource:integration-tests-js-XXXX-esm_node18",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs18.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "MODIFY someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "MODIFY someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "MODIFY",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -66,22 +216,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node18",
-    "resource:integration-tests-js-XXXX-esm_node18",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs18.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "REMOVE someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "REMOVE someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "REMOVE",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -100,22 +316,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node18",
-    "resource:integration-tests-js-XXXX-esm_node18",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs18.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "INSERT someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "INSERT someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -134,6 +416,88 @@ START
   ],
   "v": 1
 }
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:CompleteMultipartUpload",
+          "object_key": "multipart_object.txt",
+          "object_etag": "09876543210987654321098765432109-2",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 8388608,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms Memory Used: XXXX MB
 START
 {
@@ -150,5 +514,381 @@ START
     "runtime:nodejs18.x"
   ],
   "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Copy",
+          "object_key": "copied_object.txt",
+          "object_etag": "01234567890123456789012345678901",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node18",
+    "resource:integration-tests-js-XXXX-esm_node18",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs18.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Put",
+          "object_key": "test_object.txt",
+          "object_etag": "abcdef0123456789abcdef01234567890",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node18",
+    "resource:integration-tests-js-XXXX-esm_node18",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs18.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sns",
+        "resource": "sns-lambda",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSnsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "message_id": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedSnsServiceName",
+        "type": "sns"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node18",
+    "resource:integration-tests-js-XXXX-esm_node18",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs18.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sqs",
+        "resource": "my-queue",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSqsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "retry_count": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedSqsServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node18",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node18",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node18",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node18",
+          "functionname": "integration-tests-js-XXXX-esm_node18",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/esm_node20.log
+++ b/integration_tests/snapshots/logs/esm_node20.log
@@ -15,6 +15,90 @@ START
   ],
   "v": 1
 }
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.apigateway",
+        "resource": "GET /{proxy+}",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedApiGatewayServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.apigateway",
+          "http.url": "https://undefined",
+          "resource_names": "GET /{proxy+}",
+          "request_id":"XXXX",
+          "apiid":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "sync",
+          "http.method": "GET",
+          "stage": "test",
+          "domain_name": "",
+          "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedApiGatewayServiceName",
+        "type": "http"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
+          "http.method": "GET",
+          "http.route": "/{proxy+}",
+          "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 START
 {
@@ -32,22 +116,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node20",
-    "resource:integration-tests-js-XXXX-esm_node20",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs20.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "MODIFY someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "MODIFY someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "MODIFY",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -66,22 +216,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node20",
-    "resource:integration-tests-js-XXXX-esm_node20",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs20.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "REMOVE someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "REMOVE someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "REMOVE",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -100,22 +316,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node20",
-    "resource:integration-tests-js-XXXX-esm_node20",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs20.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "INSERT someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "INSERT someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -134,6 +416,88 @@ START
   ],
   "v": 1
 }
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:CompleteMultipartUpload",
+          "object_key": "multipart_object.txt",
+          "object_etag": "09876543210987654321098765432109-2",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 8388608,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms Memory Used: XXXX MB
 START
 {
@@ -150,5 +514,381 @@ START
     "runtime:nodejs20.x"
   ],
   "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Copy",
+          "object_key": "copied_object.txt",
+          "object_etag": "01234567890123456789012345678901",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node20",
+    "resource:integration-tests-js-XXXX-esm_node20",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs20.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Put",
+          "object_key": "test_object.txt",
+          "object_etag": "abcdef0123456789abcdef01234567890",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node20",
+    "resource:integration-tests-js-XXXX-esm_node20",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs20.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sns",
+        "resource": "sns-lambda",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSnsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "message_id": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedSnsServiceName",
+        "type": "sns"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node20",
+    "resource:integration-tests-js-XXXX-esm_node20",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs20.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sqs",
+        "resource": "my-queue",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSqsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "retry_count": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedSqsServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node20",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node20",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node20",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node20",
+          "functionname": "integration-tests-js-XXXX-esm_node20",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/logs/esm_node22.log
+++ b/integration_tests/snapshots/logs/esm_node22.log
@@ -15,6 +15,90 @@ START
   ],
   "v": 1
 }
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.apigateway",
+        "resource": "GET /{proxy+}",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedApiGatewayServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.apigateway",
+          "http.url": "https://undefined",
+          "resource_names": "GET /{proxy+}",
+          "request_id":"XXXX",
+          "apiid":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "sync",
+          "http.method": "GET",
+          "stage": "test",
+          "domain_name": "",
+          "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedApiGatewayServiceName",
+        "type": "http"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k/stages/test",
+          "http.method": "GET",
+          "http.route": "/{proxy+}",
+          "http.status_code": "200",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
 START
 {
@@ -32,22 +116,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node22",
-    "resource:integration-tests-js-XXXX-esm_node22",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs22.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "MODIFY someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "MODIFY someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "MODIFY",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -66,22 +216,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node22",
-    "resource:integration-tests-js-XXXX-esm_node22",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs22.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "REMOVE someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "REMOVE someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "REMOVE",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -100,22 +316,88 @@ START
   ],
   "v": 1
 }
-END Duration: XXXX ms Memory Used: XXXX MB
-START
 {
-  "e": XXXX,
-  "m": "aws.lambda.enhanced.invocations",
-  "t": [
-    "region:eu-west-1",
-    "account_id:XXXX",
-    "functionname:integration-tests-js-XXXX-esm_node22",
-    "resource:integration-tests-js-XXXX-esm_node22",
-    "memorysize:1024",
-    "cold_start:false",
-    "datadog_lambda:vX.X.X",
-    "runtime:nodejs22.x"
-  ],
-  "v": 1
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "INSERT someTableName",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "INSERT someTableName",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedDynamoDbServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
@@ -134,6 +416,88 @@ START
   ],
   "v": 1
 }
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:CompleteMultipartUpload",
+          "object_key": "multipart_object.txt",
+          "object_etag": "09876543210987654321098765432109-2",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 8388608,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
 END Duration: XXXX ms Memory Used: XXXX MB
 START
 {
@@ -150,5 +514,381 @@ START
     "runtime:nodejs22.x"
   ],
   "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Copy",
+          "object_key": "copied_object.txt",
+          "object_etag": "01234567890123456789012345678901",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node22",
+    "resource:integration-tests-js-XXXX-esm_node22",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs22.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Put",
+          "object_key": "test_object.txt",
+          "object_etag": "abcdef0123456789abcdef01234567890",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedS3ServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node22",
+    "resource:integration-tests-js-XXXX-esm_node22",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs22.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sns",
+        "resource": "sns-lambda",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSnsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "message_id": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedSnsServiceName",
+        "type": "sns"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-XXXX-esm_node22",
+    "resource:integration-tests-js-XXXX-esm_node22",
+    "memorysize:1024",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejs22.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sqs",
+        "resource": "my-queue",
+        "error": 0,
+        "meta": {
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSqsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "request_id":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "retry_count": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "remappedSqsServiceName",
+        "type": "web"
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-XXXX-esm_node22",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "service": "integration-tests-js-XXXX-esm_node22",
+          "version": "1.0.0",
+          "runtime-id":"XXXX",
+          "function_arn":"XXXX_node22",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-XXXX-esm_node22",
+          "functionname": "integration-tests-js-XXXX-esm_node22",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
+          "language": "javascript"
+        },
+        "metrics": {
+          "cold_start": 0,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": [],
+        "service": "aws.lambda",
+        "type": "serverless"
+      }
+    ]
+  ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB

--- a/integration_tests/snapshots/return_values/esm_node18_api-gateway-get.json
+++ b/integration_tests/snapshots/return_values/esm_node18_api-gateway-get.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_dynamodb-one-key-table.json
+++ b/integration_tests/snapshots/return_values/esm_node18_dynamodb-one-key-table.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_dynamodb-remove.json
+++ b/integration_tests/snapshots/return_values/esm_node18_dynamodb-remove.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_dynamodb-two-key-table.json
+++ b/integration_tests/snapshots/return_values/esm_node18_dynamodb-two-key-table.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_s3-completemultipartupload.json
+++ b/integration_tests/snapshots/return_values/esm_node18_s3-completemultipartupload.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_s3-copyobject.json
+++ b/integration_tests/snapshots/return_values/esm_node18_s3-copyobject.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_s3-putobject.json
+++ b/integration_tests/snapshots/return_values/esm_node18_s3-putobject.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_sns.json
+++ b/integration_tests/snapshots/return_values/esm_node18_sns.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node18_sqs.json
+++ b/integration_tests/snapshots/return_values/esm_node18_sqs.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_api-gateway-get.json
+++ b/integration_tests/snapshots/return_values/esm_node20_api-gateway-get.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_dynamodb-one-key-table.json
+++ b/integration_tests/snapshots/return_values/esm_node20_dynamodb-one-key-table.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_dynamodb-remove.json
+++ b/integration_tests/snapshots/return_values/esm_node20_dynamodb-remove.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_dynamodb-two-key-table.json
+++ b/integration_tests/snapshots/return_values/esm_node20_dynamodb-two-key-table.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_s3-completemultipartupload.json
+++ b/integration_tests/snapshots/return_values/esm_node20_s3-completemultipartupload.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_s3-copyobject.json
+++ b/integration_tests/snapshots/return_values/esm_node20_s3-copyobject.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_s3-putobject.json
+++ b/integration_tests/snapshots/return_values/esm_node20_s3-putobject.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_sns.json
+++ b/integration_tests/snapshots/return_values/esm_node20_sns.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node20_sqs.json
+++ b/integration_tests/snapshots/return_values/esm_node20_sqs.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_api-gateway-get.json
+++ b/integration_tests/snapshots/return_values/esm_node22_api-gateway-get.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_dynamodb-one-key-table.json
+++ b/integration_tests/snapshots/return_values/esm_node22_dynamodb-one-key-table.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_dynamodb-remove.json
+++ b/integration_tests/snapshots/return_values/esm_node22_dynamodb-remove.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_dynamodb-two-key-table.json
+++ b/integration_tests/snapshots/return_values/esm_node22_dynamodb-two-key-table.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_s3-completemultipartupload.json
+++ b/integration_tests/snapshots/return_values/esm_node22_s3-completemultipartupload.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_s3-copyobject.json
+++ b/integration_tests/snapshots/return_values/esm_node22_s3-copyobject.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_s3-putobject.json
+++ b/integration_tests/snapshots/return_values/esm_node22_s3-putobject.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_sns.json
+++ b/integration_tests/snapshots/return_values/esm_node22_sns.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/integration_tests/snapshots/return_values/esm_node22_sqs.json
+++ b/integration_tests/snapshots/return_values/esm_node22_sqs.json
@@ -1,1 +1,3 @@
-null
+{
+    "message": "hello, dog!"
+}

--- a/src/utils/handler.spec.ts
+++ b/src/utils/handler.spec.ts
@@ -325,4 +325,34 @@ describe("wrap", () => {
     expect(calledComplete).toBeTruthy();
     expect(calledOriginalHandler).toBeFalsy();
   });
+
+  it("completes when handler returns a value directly (sync handler)", async () => {
+    const handler = (event: any, context: Context) => {
+      // Return a value directly without using callback or promise
+      return { statusCode: 200, body: "Sync response" };
+    };
+
+    let calledStart = false;
+    let calledComplete = false;
+    let calledOriginalHandler = false;
+
+    const wrappedHandler = wrap(
+      handler as any,
+      async () => {
+        calledStart = true;
+      },
+      async () => {
+        calledComplete = true;
+      },
+    );
+
+    const result = await wrappedHandler({}, mockContext, () => {
+      calledOriginalHandler = true;
+    });
+
+    expect(result).toEqual({ statusCode: 200, body: "Sync response" });
+    expect(calledStart).toBeTruthy();
+    expect(calledComplete).toBeTruthy();
+    expect(calledOriginalHandler).toBeFalsy();
+  });
 });

--- a/src/utils/handler.ts
+++ b/src/utils/handler.ts
@@ -124,6 +124,9 @@ export function promisifiedHandler<TEvent, TResult>(handler: Handler<TEvent, TRe
     } else if (asyncProm === undefined && handler.length < 3) {
       // Handler returned undefined and doesn't take a callback parameter, resolve immediately
       promise = Promise.resolve(undefined);
+    } else {
+      // Handler returned a value directly, resolve with that value
+      promise = Promise.resolve(asyncProm);
     }
     return promise;
   };

--- a/src/utils/handler.ts
+++ b/src/utils/handler.ts
@@ -124,8 +124,11 @@ export function promisifiedHandler<TEvent, TResult>(handler: Handler<TEvent, TRe
     } else if (asyncProm === undefined && handler.length < 3) {
       // Handler returned undefined and doesn't take a callback parameter, resolve immediately
       promise = Promise.resolve(undefined);
+    } else if (handler.length >= 3) {
+      // Handler takes a callback, wait for the callback to be called
+      promise = callbackProm;
     } else {
-      // Handler returned a value directly, resolve with that value
+      // Handler returned a value directly (sync handler with return value), resolve with that value
       promise = Promise.resolve(asyncProm);
     }
     return promise;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
The original code handled cases:
- Handler returned a Promise (async functions)
- Handler returned undefined with < 3 parameters

But it didn't handle the case where a sync handler returned a non-undefined value (like return 200). So sync handlers returning values weren't promisified, causing the datadog wrapper to not wait for the handler's result

### Motivation

https://datadoghq.atlassian.net/browse/SLES-2296
https://github.com/osadi/dd-timeout-repro

### Testing Guidelines

Tested manually

Unit tests fail without these changes; pass with the changes

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
