### PR TITLE
fix: reset tracecontext to avoid unintentional caching

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -63,6 +63,10 @@ jest.mock("./trace/trace-context-service", () => {
     get currentTraceHeaders() {
       return mockTraceHeaders;
     }
+
+    reset(){
+      // mocking
+    }
   }
   return {
     ...jest.requireActual("./trace/trace-context-service"),

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -64,7 +64,7 @@ jest.mock("./trace/trace-context-service", () => {
       return mockTraceHeaders;
     }
 
-    reset(){
+    reset() {
       // mocking
     }
   }

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -68,6 +68,8 @@ jest.mock("./trace-context-service", () => {
     get currentTraceContext() {
       return mockSpanContextWrapper;
     }
+    reset() { // mocking
+    }
   }
   return {
     ...jest.requireActual("./trace-context-service"),

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -68,7 +68,8 @@ jest.mock("./trace-context-service", () => {
     get currentTraceContext() {
       return mockSpanContextWrapper;
     }
-    reset() { // mocking
+    reset() {
+      // mocking
     }
   }
   return {

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -279,9 +279,10 @@ export class TraceListener {
       this.injectAuthorizerSpan(result, event?.requestContext?.requestId, finishTime || Date.now());
     }
 
-    // Reset singleton
+    // Reset singletons and trace context
     this.stepFunctionContext = undefined;
     StepFunctionContextService.reset();
+    this.contextService.reset();
   }
 
   public onWrap<T = (...args: any[]) => any>(func: T): T {

--- a/src/trace/trace-context-service.ts
+++ b/src/trace/trace-context-service.ts
@@ -50,6 +50,9 @@ export class TraceContextService {
   }
 
   async extract(event: any, context: Context): Promise<SpanContextWrapper | null> {
+    // Reset trace context from previous invocation to prevent caching
+    this.rootTraceContext = null;
+
     this.rootTraceContext = await this.traceExtractor?.extract(event, context);
 
     return this.currentTraceContext;
@@ -81,5 +84,9 @@ export class TraceContextService {
 
   get traceSource() {
     return this.rootTraceContext !== null ? this.rootTraceContext?.source : null;
+  }
+
+  reset() {
+    this.rootTraceContext = null;
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
The customer is experiencing a case where multiple lambda invocations are put into one trace even though they have different tracecontext in their payload. This indicates that the `rootTraceContext` was reused/cached unintentionally. 

### Motivation
https://datadoghq.atlassian.net/browse/APMS-17080

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
