### PR TITLE
fix: skip API key retrieval when extension is running

### DIFF
--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -74,13 +74,6 @@ export class MetricsListener {
   }
 
   public async onStartInvocation(_: any, context?: Context) {
-    // We get the API key in onStartInvocation rather than in the constructor because in busy functions,
-    // initialization may occur more than 5 minutes before the first invocation (due to proactive initialization),
-    // resulting in AWS errors: https://github.com/aws/aws-sdk-js-v3/issues/5192#issuecomment-2073243617
-    if (!this.apiKey) {
-      this.apiKey = this.getAPIKey(this.config);
-    }
-
     if (this.isExtensionRunning === undefined) {
       this.isExtensionRunning = await isExtensionRunning();
       logDebug(`Extension present: ${this.isExtensionRunning}`);
@@ -98,6 +91,12 @@ export class MetricsListener {
       return;
     }
 
+    // We get the API key in onStartInvocation rather than in the constructor because in busy functions,
+    // initialization may occur more than 5 minutes before the first invocation (due to proactive initialization),
+    // resulting in AWS errors: https://github.com/aws/aws-sdk-js-v3/issues/5192#issuecomment-2073243617
+    if (!this.apiKey) {
+      this.apiKey = this.getAPIKey(this.config);
+    }
     this.currentProcessor = this.createProcessor(this.config, this.apiKey);
   }
 


### PR DESCRIPTION
Clone of https://github.com/DataDog/datadog-lambda-js/pull/680  
Just to run the tests, do not merge!


Move getAPIKey call to avoid unnecessary Secrets Manager calls when Datadog Lambda Extension is present, preventing Signature expired errors in provisioned concurrency environments.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
