### PR TITLE
feat: [SVLS-8721] add first_invocation tag for durable functions

### DIFF
--- a/src/trace/durable-function-context.spec.ts
+++ b/src/trace/durable-function-context.spec.ts
@@ -58,7 +58,45 @@ describe("durable-function-context", () => {
       expect(result).toEqual({
         "aws_lambda.durable_function.execution_name": "my-execution",
         "aws_lambda.durable_function.execution_id": "550e8400-e29b-41d4-a716-446655440004",
+        "aws_lambda.durable_function.first_invocation": "false",
       });
+    });
+
+    it("sets first_invocation to true when Operations has exactly one entry", () => {
+      const event = {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+        InitialExecutionState: {
+          Operations: [{ type: "TaskScheduled" }],
+        },
+      };
+      const result = extractDurableFunctionContext(event);
+
+      expect(result?.["aws_lambda.durable_function.first_invocation"]).toBe("true");
+    });
+
+    it("sets first_invocation to false when Operations has more than one entry", () => {
+      const event = {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+        InitialExecutionState: {
+          Operations: [{ type: "TaskScheduled" }, { type: "TaskCompleted" }],
+        },
+      };
+      const result = extractDurableFunctionContext(event);
+
+      expect(result?.["aws_lambda.durable_function.first_invocation"]).toBe("false");
+    });
+
+    it("omits first_invocation when InitialExecutionState is absent", () => {
+      const event = {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+      };
+      const result = extractDurableFunctionContext(event);
+
+      expect(result).toBeDefined();
+      expect(result?.["aws_lambda.durable_function.first_invocation"]).toBeUndefined();
     });
 
     it("returns undefined for regular Lambda event without DurableExecutionArn", () => {

--- a/src/trace/durable-function-context.ts
+++ b/src/trace/durable-function-context.ts
@@ -3,6 +3,7 @@ import { logDebug } from "../utils";
 export interface DurableFunctionContext {
   "aws_lambda.durable_function.execution_name": string;
   "aws_lambda.durable_function.execution_id": string;
+  "aws_lambda.durable_function.first_invocation"?: string;
 }
 
 export function extractDurableFunctionContext(event: any): DurableFunctionContext | undefined {
@@ -18,10 +19,18 @@ export function extractDurableFunctionContext(event: any): DurableFunctionContex
     return undefined;
   }
 
-  return {
+  const context: DurableFunctionContext = {
     "aws_lambda.durable_function.execution_name": parsed.executionName,
     "aws_lambda.durable_function.execution_id": parsed.executionId,
   };
+
+  // Use the number of operations to determine if it's the first invocation.
+  const operations = event?.InitialExecutionState?.Operations;
+  if (Array.isArray(operations)) {
+    context["aws_lambda.durable_function.first_invocation"] = String(operations.length === 1);
+  }
+
+  return context;
 }
 
 /**

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -227,6 +227,7 @@ export class TraceListener {
       }
     }
     if (this.durableFunctionContext) {
+      logDebug("Applying durable function context to the aws.lambda span");
       for (const [key, value] of Object.entries(this.durableFunctionContext)) {
         if (value !== undefined) {
           this.tracerWrapper.currentSpan.setTag(key, value);

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -227,7 +227,6 @@ export class TraceListener {
       }
     }
     if (this.durableFunctionContext) {
-      logDebug("Applying durable function context to the aws.lambda span");
       for (const [key, value] of Object.entries(this.durableFunctionContext)) {
         if (value !== undefined) {
           this.tracerWrapper.currentSpan.setTag(key, value);


### PR DESCRIPTION
## Summary

- Adds `aws_lambda.durable_function.first_invocation` span tag for AWS Lambda durable functions
- Tag is `"true"` when `InitialExecutionState.Operations` has exactly one entry (first invocation), `"false"` when it has more entries (replay)
- Tag is omitted when `InitialExecutionState` is absent from the event
- Mirrors the same change made in the Python tracer: DataDog/datadog-lambda-python#747

## Testing
Built a layer, installed it on a function, then invoke the function.

The `aws.lambda` span for the first invocation has tag `first_invocation:true`
<img width="530" height="347" alt="image" src="https://github.com/user-attachments/assets/4e582f3b-75ef-4796-b1fb-86db788729e7" />

This is `false` for the second invocation.
<img width="532" height="339" alt="image" src="https://github.com/user-attachments/assets/a3198b0b-84ea-4e7c-beb4-a20c9cc6309c" />
