### PR TITLE
fix: [SVLS-8538] apply durable function tags via setTag on the active span

### DIFF
--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -544,4 +544,28 @@ describe("TraceListener", () => {
       );
     });
   });
+
+  it("sets durable function context tags directly on the aws.lambda span", async () => {
+    const mockSetTag = jest.fn();
+    const mockSpan = { setTag: mockSetTag };
+    const currentSpanSpy = jest.spyOn(TracerWrapper.prototype, "currentSpan", "get").mockReturnValue(mockSpan);
+
+    try {
+      const listener = new TraceListener(defaultConfig);
+      const durableEvent = {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+      };
+      await listener.onStartInvocation(durableEvent, context as any);
+      listener.onEndingInvocation(durableEvent, {}, false);
+
+      expect(mockSetTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_name", "my-execution");
+      expect(mockSetTag).toHaveBeenCalledWith(
+        "aws_lambda.durable_function.execution_id",
+        "550e8400-e29b-41d4-a716-446655440004",
+      );
+    } finally {
+      currentSpanSpy.mockRestore();
+    }
+  });
 });

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -227,6 +227,7 @@ export class TraceListener {
       }
     }
     if (this.durableFunctionContext) {
+      logDebug("Applying durable function context to the aws.lambda span");
       for (const [key, value] of Object.entries(this.durableFunctionContext)) {
         if (value !== undefined) {
           this.tracerWrapper.currentSpan.setTag(key, value);

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -226,6 +226,14 @@ export class TraceListener {
         }
       }
     }
+    if (this.durableFunctionContext) {
+      logDebug("Applying durable function context to the aws.lambda span");
+      for (const [key, value] of Object.entries(this.durableFunctionContext)) {
+        if (value !== undefined) {
+          this.tracerWrapper.currentSpan.setTag(key, value);
+        }
+      }
+    }
 
     let rootSpan = this.inferredSpan;
     if (!rootSpan) {
@@ -335,13 +343,6 @@ export class TraceListener {
       options.tags = {
         ...options.tags,
         ...this.stepFunctionContext,
-      };
-    }
-    if (this.durableFunctionContext) {
-      logDebug("Applying durable function context to the aws.lambda span");
-      options.tags = {
-        ...options.tags,
-        ...this.durableFunctionContext,
       };
     }
     if (this.lambdaSpanParentContext) {

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -227,7 +227,6 @@ export class TraceListener {
       }
     }
     if (this.durableFunctionContext) {
-      logDebug("Applying durable function context to the aws.lambda span");
       for (const [key, value] of Object.entries(this.durableFunctionContext)) {
         if (value !== undefined) {
           this.tracerWrapper.currentSpan.setTag(key, value);


### PR DESCRIPTION
## Problem
The tags `aws_lambda.durable_function.execution_name` and `aws_lambda.durable_function.execution_id` do not appear on the `aws.lambda` span as expected.

## Summary

- The tags were being passed through `options.tags` in `tracer.wrap()`, but that path does not reliably propagate to the actual span
- Fix: apply them directly via `span.setTag()` in `onEndingInvocation()`, the same mechanism used for `http.status_code`
- Added a test verifying `setTag` is called with the durable function context values

## Test
**Steps:**
- Build a JS layer
- Install it on a function
- Invoke the function

**Result:**
Tags appear on the `aws.lambda` span
<img width="511" height="213" alt="image" src="https://github.com/user-attachments/assets/ba50090e-f867-4ae0-b342-7116d9293422" />