### PR TITLE
Add durable_function_execution_status tag to aws.lambda span

### DIFF
--- a/src/trace/durable-function-context.spec.ts
+++ b/src/trace/durable-function-context.spec.ts
@@ -1,4 +1,8 @@
-import { parseDurableExecutionArn, extractDurableFunctionContext } from "./durable-function-context";
+import {
+  parseDurableExecutionArn,
+  extractDurableFunctionContext,
+  extractDurableExecutionStatus,
+} from "./durable-function-context";
 
 describe("durable-function-context", () => {
   describe("parseDurableExecutionArn", () => {
@@ -92,6 +96,58 @@ describe("durable-function-context", () => {
       const result = extractDurableFunctionContext(event);
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("extractDurableExecutionStatus", () => {
+    const durableEvent = {
+      DurableExecutionArn: "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/exec/id-1",
+    };
+
+    it("returns SUCCEEDED for a durable invocation with Status SUCCEEDED", () => {
+      expect(extractDurableExecutionStatus({ Status: "SUCCEEDED" }, durableEvent)).toBe("SUCCEEDED");
+    });
+
+    it("returns FAILED for a durable invocation with Status FAILED", () => {
+      expect(extractDurableExecutionStatus({ Status: "FAILED" }, durableEvent)).toBe("FAILED");
+    });
+
+    it("returns STOPPED for a durable invocation with Status STOPPED", () => {
+      expect(extractDurableExecutionStatus({ Status: "STOPPED" }, durableEvent)).toBe("STOPPED");
+    });
+
+    it("returns TIMED_OUT for a durable invocation with Status TIMED_OUT", () => {
+      expect(extractDurableExecutionStatus({ Status: "TIMED_OUT" }, durableEvent)).toBe("TIMED_OUT");
+    });
+
+    it("returns undefined for unrecognized status value", () => {
+      expect(extractDurableExecutionStatus({ Status: "RUNNING" }, durableEvent)).toBeUndefined();
+    });
+
+    it("returns undefined when Status field is absent from result", () => {
+      expect(extractDurableExecutionStatus({}, durableEvent)).toBeUndefined();
+    });
+
+    it("returns undefined when event does not have DurableExecutionArn", () => {
+      const nonDurableEvent = { body: '{"key":"value"}' };
+      expect(extractDurableExecutionStatus({ Status: "SUCCEEDED" }, nonDurableEvent)).toBeUndefined();
+    });
+
+    it("returns undefined when event is null", () => {
+      expect(extractDurableExecutionStatus({ Status: "SUCCEEDED" }, null)).toBeUndefined();
+    });
+
+    it("returns undefined when result is null", () => {
+      expect(extractDurableExecutionStatus(null, durableEvent)).toBeUndefined();
+    });
+
+    it("returns undefined when result is a non-object (string)", () => {
+      expect(extractDurableExecutionStatus("SUCCEEDED", durableEvent)).toBeUndefined();
+    });
+
+    it("does not apply status from non-durable invocations that happen to return Status field", () => {
+      const nonDurableEvent = { httpMethod: "GET" };
+      expect(extractDurableExecutionStatus({ Status: "SUCCEEDED" }, nonDurableEvent)).toBeUndefined();
     });
   });
 });

--- a/src/trace/durable-function-context.ts
+++ b/src/trace/durable-function-context.ts
@@ -35,3 +35,24 @@ export function parseDurableExecutionArn(arn: string): { executionName: string; 
   const [, executionName, executionId] = match;
   return { executionName, executionId };
 }
+
+const VALID_EXECUTION_STATUSES = new Set(["SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"]);
+
+/**
+ * Extracts the durable function execution status from the Lambda result.
+ * Only applies when the event contains a DurableExecutionArn (i.e., this is a durable function invocation).
+ * Returns undefined if the event is not a durable invocation or if the status is absent/unrecognized.
+ */
+export function extractDurableExecutionStatus(result: any, event: any): string | undefined {
+  if (typeof event?.DurableExecutionArn !== "string") {
+    return undefined;
+  }
+  if (result === null || typeof result !== "object") {
+    return undefined;
+  }
+  const status = result.Status;
+  if (typeof status === "string" && VALID_EXECUTION_STATUSES.has(status)) {
+    return status;
+  }
+  return undefined;
+}

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -544,4 +544,75 @@ describe("TraceListener", () => {
       );
     });
   });
+
+  describe("onEndingInvocation durable function execution status", () => {
+    const durableEvent = {
+      DurableExecutionArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+    };
+
+    let mockSpan: { setTag: jest.Mock };
+    let currentSpanSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      mockSpan = { setTag: jest.fn() };
+      currentSpanSpy = jest.spyOn(TracerWrapper.prototype, "currentSpan", "get").mockReturnValue(mockSpan);
+    });
+
+    afterEach(() => {
+      currentSpanSpy.mockRestore();
+    });
+
+    it("sets aws_lambda.durable_function.execution_status tag on durable invocation with SUCCEEDED", () => {
+      const listener = new TraceListener(defaultConfig);
+      listener.onEndingInvocation(durableEvent, { Status: "SUCCEEDED" }, false);
+
+      expect(mockSpan.setTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", "SUCCEEDED");
+    });
+
+    it("sets aws_lambda.durable_function.execution_status tag on durable invocation with FAILED", () => {
+      const listener = new TraceListener(defaultConfig);
+      listener.onEndingInvocation(durableEvent, { Status: "FAILED" }, false);
+
+      expect(mockSpan.setTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", "FAILED");
+    });
+
+    it("sets aws_lambda.durable_function.execution_status tag on durable invocation with STOPPED", () => {
+      const listener = new TraceListener(defaultConfig);
+      listener.onEndingInvocation(durableEvent, { Status: "STOPPED" }, false);
+
+      expect(mockSpan.setTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", "STOPPED");
+    });
+
+    it("does not set execution_status tag for non-durable invocations", () => {
+      const listener = new TraceListener(defaultConfig);
+      const nonDurableEvent = { httpMethod: "GET", body: "{}" };
+      listener.onEndingInvocation(nonDurableEvent, { Status: "SUCCEEDED" }, false);
+
+      const statusTagCalls = mockSpan.setTag.mock.calls.filter(
+        ([key]: [string]) => key === "aws_lambda.durable_function.execution_status",
+      );
+      expect(statusTagCalls).toHaveLength(0);
+    });
+
+    it("does not set execution_status tag when result has no Status field", () => {
+      const listener = new TraceListener(defaultConfig);
+      listener.onEndingInvocation(durableEvent, {}, false);
+
+      const statusTagCalls = mockSpan.setTag.mock.calls.filter(
+        ([key]: [string]) => key === "aws_lambda.durable_function.execution_status",
+      );
+      expect(statusTagCalls).toHaveLength(0);
+    });
+
+    it("does not set execution_status tag for unrecognized status values", () => {
+      const listener = new TraceListener(defaultConfig);
+      listener.onEndingInvocation(durableEvent, { Status: "RUNNING" }, false);
+
+      const statusTagCalls = mockSpan.setTag.mock.calls.filter(
+        ([key]: [string]) => key === "aws_lambda.durable_function.execution_status",
+      );
+      expect(statusTagCalls).toHaveLength(0);
+    });
+  });
 });

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -20,7 +20,11 @@ import { SpanWrapper } from "./span-wrapper";
 import { getTraceTree, clearTraceTree } from "../runtime/index";
 import { TraceContext, TraceContextService, TraceSource } from "./trace-context-service";
 import { StepFunctionContext, StepFunctionContextService } from "./step-function-service";
-import { DurableFunctionContext, extractDurableFunctionContext } from "./durable-function-context";
+import {
+  DurableFunctionContext,
+  extractDurableFunctionContext,
+  extractDurableExecutionStatus,
+} from "./durable-function-context";
 import { XrayService } from "./xray-service";
 import { AUTHORIZING_REQUEST_ID_HEADER } from "./context/extractors/http";
 import { getSpanPointerAttributes, SpanPointerAttributes } from "../utils/span-pointers";
@@ -225,6 +229,12 @@ export class TraceListener {
           return true;
         }
       }
+    }
+
+    const durableExecutionStatus = extractDurableExecutionStatus(result, event);
+    if (durableExecutionStatus !== undefined) {
+      logDebug("Applying durable function execution status to the aws.lambda span");
+      this.tracerWrapper.currentSpan.setTag("aws_lambda.durable_function.execution_status", durableExecutionStatus);
     }
 
     let rootSpan = this.inferredSpan;


### PR DESCRIPTION
## What

Adds a new span tag `aws_lambda.durable_function.execution_status` to the `aws.lambda` span for Lambda Durable Function invocations.

At the end of a Lambda invocation, if the event contains a `DurableExecutionArn` (indicating a durable function execution), the handler response's `Status` field is extracted and set as the tag value.

**Valid values**: `SUCCEEDED`, `FAILED`, `STOPPED`, `TIMED_OUT`

## Why

Supports observability for Lambda Durable Functions by surfacing execution status on the `aws.lambda` span. This is the JS implementation of the feature already shipped in Python (SVLS-8580).

## Implementation

- `src/trace/durable-function-context.ts`: Added `extractDurableExecutionStatus(result, event)` — guards on `DurableExecutionArn` in the event, reads `result.Status` (capital S, per AWS convention), validates against the allowed set, returns `undefined` otherwise.
- `src/trace/listener.ts`: In `onEndingInvocation()`, after the `triggerTags` block, calls `extractDurableExecutionStatus` and sets the tag if a valid status is returned.

## Testing

**Unit tests** (50/50 pass):
- `src/trace/durable-function-context.spec.ts`: 11 tests covering all valid statuses, invalid status (RUNNING), absent Status field, non-durable event guard, null/non-object result.
- `src/trace/listener.spec.ts`: 5 tests covering SUCCEEDED/FAILED/STOPPED tag application, non-durable guard (tag absent), missing Status field, unrecognized status.

**Integration tests** (9/9 pass against real Lambda functions):
- `durable-succeeded`: Invocation with `DurableExecutionArn` + `Status: SUCCEEDED` → tag set on `aws.lambda` span ✓
- `durable-failed`: Invocation with `DurableExecutionArn` + `Status: FAILED` → tag set on `aws.lambda` span ✓
- `non-durable`: Invocation without `DurableExecutionArn` → tag absent (guard working) ✓

## Notes

- Tag name follows the SVLS-8493 rename convention (`aws_lambda.durable_function.*`).
- `TIMED_OUT` is included for parity with the Python implementation, though it was listed as out-of-scope in the ticket.

Jira: [SVLS-8583](https://datadoghq.atlassian.net/browse/SVLS-8583)