### PR TITLE
[SVLS-8583] Add execution_status tag to aws.lambda span for durable functions

### DIFF
--- a/src/trace/durable-function-context.spec.ts
+++ b/src/trace/durable-function-context.spec.ts
@@ -1,4 +1,8 @@
-import { parseDurableExecutionArn, extractDurableFunctionContext, extractDurableExecutionStatus } from "./durable-function-context";
+import {
+  parseDurableExecutionArn,
+  extractDurableFunctionContext,
+  extractDurableExecutionStatus,
+} from "./durable-function-context";
 
 describe("durable-function-context", () => {
   describe("parseDurableExecutionArn", () => {

--- a/src/trace/durable-function-context.spec.ts
+++ b/src/trace/durable-function-context.spec.ts
@@ -143,7 +143,7 @@ describe("durable-function-context", () => {
         "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
     };
 
-    it.each(["SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"])("returns %s when result.Status is %s", (status) => {
+    it.each(["SUCCEEDED", "FAILED", "PENDING"])("returns %s when result.Status is %s", (status) => {
       const result = extractDurableExecutionStatus(durableEvent, { Status: status });
       expect(result).toBe(status);
     });

--- a/src/trace/durable-function-context.spec.ts
+++ b/src/trace/durable-function-context.spec.ts
@@ -1,4 +1,4 @@
-import { parseDurableExecutionArn, extractDurableFunctionContext } from "./durable-function-context";
+import { parseDurableExecutionArn, extractDurableFunctionContext, extractDurableExecutionStatus } from "./durable-function-context";
 
 describe("durable-function-context", () => {
   describe("parseDurableExecutionArn", () => {
@@ -129,6 +129,43 @@ describe("durable-function-context", () => {
       };
       const result = extractDurableFunctionContext(event);
 
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("extractDurableExecutionStatus", () => {
+    const durableEvent = {
+      DurableExecutionArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+    };
+
+    it.each(["SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"])("returns %s when result.Status is %s", (status) => {
+      const result = extractDurableExecutionStatus(durableEvent, { Status: status });
+      expect(result).toBe(status);
+    });
+
+    it("returns undefined when result.Status is not a valid status", () => {
+      const result = extractDurableExecutionStatus(durableEvent, { Status: "UNKNOWN" });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when result has no Status field", () => {
+      const result = extractDurableExecutionStatus(durableEvent, {});
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when result is null", () => {
+      const result = extractDurableExecutionStatus(durableEvent, null);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when event has no DurableExecutionArn", () => {
+      const result = extractDurableExecutionStatus({ body: "{}" }, { Status: "SUCCEEDED" });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when event is null", () => {
+      const result = extractDurableExecutionStatus(null, { Status: "SUCCEEDED" });
       expect(result).toBeUndefined();
     });
   });

--- a/src/trace/durable-function-context.ts
+++ b/src/trace/durable-function-context.ts
@@ -6,7 +6,7 @@ export interface DurableFunctionContext {
   "aws_lambda.durable_function.first_invocation"?: string;
 }
 
-const VALID_DURABLE_EXECUTION_STATUSES = new Set(["SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"]);
+const VALID_DURABLE_EXECUTION_STATUSES = new Set(["SUCCEEDED", "FAILED", "PENDING"]);
 
 export function extractDurableFunctionContext(event: any): DurableFunctionContext | undefined {
   const durableExecutionArn = event?.DurableExecutionArn;

--- a/src/trace/durable-function-context.ts
+++ b/src/trace/durable-function-context.ts
@@ -6,6 +6,8 @@ export interface DurableFunctionContext {
   "aws_lambda.durable_function.first_invocation"?: string;
 }
 
+const VALID_DURABLE_EXECUTION_STATUSES = new Set(["SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"]);
+
 export function extractDurableFunctionContext(event: any): DurableFunctionContext | undefined {
   const durableExecutionArn = event?.DurableExecutionArn;
 
@@ -31,6 +33,23 @@ export function extractDurableFunctionContext(event: any): DurableFunctionContex
   }
 
   return context;
+}
+
+/**
+ * Extracts the durable function execution status from the handler result.
+ * Only applies when the event contains a DurableExecutionArn.
+ */
+export function extractDurableExecutionStatus(event: any, result: any): string | undefined {
+  if (!event?.DurableExecutionArn) {
+    return undefined;
+  }
+
+  const status = result?.Status;
+  if (typeof status !== "string" || !VALID_DURABLE_EXECUTION_STATUSES.has(status)) {
+    return undefined;
+  }
+
+  return status;
 }
 
 /**

--- a/src/trace/durable-function-context.ts
+++ b/src/trace/durable-function-context.ts
@@ -40,7 +40,7 @@ export function extractDurableFunctionContext(event: any): DurableFunctionContex
  * Only applies when the event contains a DurableExecutionArn.
  */
 export function extractDurableExecutionStatus(event: any, result: any): string | undefined {
-  if (!event?.DurableExecutionArn) {
+  if (typeof event?.DurableExecutionArn !== "string") {
     return undefined;
   }
 

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -568,4 +568,44 @@ describe("TraceListener", () => {
       currentSpanSpy.mockRestore();
     }
   });
+
+  it("sets execution_status tag on the aws.lambda span when result.Status is valid", async () => {
+    const mockSetTag = jest.fn();
+    const mockSpan = { setTag: mockSetTag };
+    const currentSpanSpy = jest.spyOn(TracerWrapper.prototype, "currentSpan", "get").mockReturnValue(mockSpan);
+
+    try {
+      const listener = new TraceListener(defaultConfig);
+      const durableEvent = {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+      };
+      await listener.onStartInvocation(durableEvent, context as any);
+      listener.onEndingInvocation(durableEvent, { Status: "SUCCEEDED" }, false);
+
+      expect(mockSetTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", "SUCCEEDED");
+    } finally {
+      currentSpanSpy.mockRestore();
+    }
+  });
+
+  it("does not set execution_status tag when result.Status is invalid", async () => {
+    const mockSetTag = jest.fn();
+    const mockSpan = { setTag: mockSetTag };
+    const currentSpanSpy = jest.spyOn(TracerWrapper.prototype, "currentSpan", "get").mockReturnValue(mockSpan);
+
+    try {
+      const listener = new TraceListener(defaultConfig);
+      const durableEvent = {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:1/durable-execution/my-execution/550e8400-e29b-41d4-a716-446655440004",
+      };
+      await listener.onStartInvocation(durableEvent, context as any);
+      listener.onEndingInvocation(durableEvent, { Status: "UNKNOWN" }, false);
+
+      expect(mockSetTag).not.toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", expect.anything());
+    } finally {
+      currentSpanSpy.mockRestore();
+    }
+  });
 });

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -237,10 +237,10 @@ export class TraceListener {
           this.tracerWrapper.currentSpan.setTag(key, value);
         }
       }
-      const executionStatus = extractDurableExecutionStatus(event, result);
-      if (executionStatus !== undefined) {
-        this.tracerWrapper.currentSpan.setTag("aws_lambda.durable_function.execution_status", executionStatus);
-      }
+    }
+    const executionStatus = extractDurableExecutionStatus(event, result);
+    if (executionStatus !== undefined) {
+      this.tracerWrapper.currentSpan.setTag("aws_lambda.durable_function.execution_status", executionStatus);
     }
 
     let rootSpan = this.inferredSpan;

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -20,7 +20,11 @@ import { SpanWrapper } from "./span-wrapper";
 import { getTraceTree, clearTraceTree } from "../runtime/index";
 import { TraceContext, TraceContextService, TraceSource } from "./trace-context-service";
 import { StepFunctionContext, StepFunctionContextService } from "./step-function-service";
-import { DurableFunctionContext, extractDurableFunctionContext, extractDurableExecutionStatus } from "./durable-function-context";
+import {
+  DurableFunctionContext,
+  extractDurableFunctionContext,
+  extractDurableExecutionStatus,
+} from "./durable-function-context";
 import { XrayService } from "./xray-service";
 import { AUTHORIZING_REQUEST_ID_HEADER } from "./context/extractors/http";
 import { getSpanPointerAttributes, SpanPointerAttributes } from "../utils/span-pointers";

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -20,7 +20,7 @@ import { SpanWrapper } from "./span-wrapper";
 import { getTraceTree, clearTraceTree } from "../runtime/index";
 import { TraceContext, TraceContextService, TraceSource } from "./trace-context-service";
 import { StepFunctionContext, StepFunctionContextService } from "./step-function-service";
-import { DurableFunctionContext, extractDurableFunctionContext } from "./durable-function-context";
+import { DurableFunctionContext, extractDurableFunctionContext, extractDurableExecutionStatus } from "./durable-function-context";
 import { XrayService } from "./xray-service";
 import { AUTHORIZING_REQUEST_ID_HEADER } from "./context/extractors/http";
 import { getSpanPointerAttributes, SpanPointerAttributes } from "../utils/span-pointers";
@@ -232,6 +232,10 @@ export class TraceListener {
         if (value !== undefined) {
           this.tracerWrapper.currentSpan.setTag(key, value);
         }
+      }
+      const executionStatus = extractDurableExecutionStatus(event, result);
+      if (executionStatus !== undefined) {
+        this.tracerWrapper.currentSpan.setTag("aws_lambda.durable_function.execution_status", executionStatus);
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds `aws_lambda.durable_function.execution_status` tag to the `aws.lambda` span for durable function invocations
- Tag is set from `result.Status` in the handler response; valid values are `SUCCEEDED`, `FAILED`, `PENDING` (matching the `InvocationStatus` enum in the durable execution SDK)
- Applied whenever the event contains a `DurableExecutionArn`, independent of whether ARN parsing succeeds
- Mirrors the implementation in the Python tracer: DataDog/datadog-lambda-python#751

## Automated testing
- [x] Unit tests added for `extractDurableExecutionStatus` in `durable-function-context.spec.ts` covering all valid statuses, invalid status, missing status, null result, and non-durable events
- [x] Tests added in `listener.spec.ts` to verify the status tag is set when `result.Status` is valid and not set otherwise
- [x] All tests pass

## Manual testing
Tested with a durable function which has 2 invocations in an execution.

The `aws.lambda` span for the 1st invocation has tag `execution_status:PENDING` ([link](https://ddserverless.datadoghq.com/serverless/aws/lambda?search=functionname%3Ayiming-durable-node&fromUser=false&graphType=flamegraph&panel_end=1776223380000&panel_paused=false&panel_start=1776219780000&shouldShowLegend=true&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Byiming-durable-node%2Bus-east-2%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%2C%7B%22p%22%3A%7B%22traceID%22%3A%223443968967758942804%22%2C%22selectedSpanID%22%3A%223443968967758942804%22%7D%2C%22i%22%3A%22trace-panel%22%7D%5D&spanID=3443968967758942804&traceID=3443968967758942804&traceQuery=&start=1776219780000&end=1776223380000&paused=false))

<img width="528" height="381" alt="image" src="https://github.com/user-attachments/assets/c6324710-9923-4c58-8027-7205c5045447" />

For the 2nd invocation, the tag is `execution_status:FAILED` ([link](https://ddserverless.datadoghq.com/serverless/aws/lambda?search=functionname%3Ayiming-durable-node&fromUser=false&graphType=flamegraph&panel_end=1776223592310&panel_paused=false&panel_start=1776219992310&shouldShowLegend=true&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Byiming-durable-node%2Bus-east-2%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%2C%7B%22p%22%3A%7B%22traceID%22%3A%225800710847622376349%22%2C%22selectedSpanID%22%3A%225800710847622376349%22%7D%2C%22i%22%3A%22trace-panel%22%7D%5D&spanID=5800710847622376349&traceID=5800710847622376349&traceQuery=&start=1776219780000&end=1776223380000&paused=false)) or `execution_status:SUCCEEDED` ([link](https://ddserverless.datadoghq.com/serverless/aws/lambda?search=functionname%3Ayiming-durable-node&fromUser=false&graphType=flamegraph&panel_end=1776223718024&panel_paused=false&panel_start=1776220118024&shouldShowLegend=true&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Byiming-durable-node%2Bus-east-2%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%2C%7B%22p%22%3A%7B%22traceID%22%3A%223405069589381215862%22%2C%22selectedSpanID%22%3A%223405069589381215862%22%7D%2C%22i%22%3A%22trace-panel%22%7D%5D&spanID=3405069589381215862&traceID=3405069589381215862&traceQuery=&start=1776220020000&end=1776223620000&paused=false))

<img width="531" height="344" alt="image" src="https://github.com/user-attachments/assets/da775acb-99a4-4324-9d14-16821ba55c1c" />

<img width="532" height="316" alt="image" src="https://github.com/user-attachments/assets/0f653379-5906-43ef-b83e-244b5c5b04d9" />

## Note
Before an execution finishes (either fails or succeeds), the status is shown as RUNNING, even if the execution is paused. I'm planning to do the same on our UI, so the `PENDING` status won't be used, but still adding it as a tag because it's also informative as a tag itself.

## Next steps
1. Do the same thing for Python tracer. Right now Python tracer expects STOPPED and TIMED_OUT statuses (among others) from durable execution SDK, which is wrong. We should remove them and add PENDING.
2. Build UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)