### PR TITLE
support us2 govcloud environment

### DIFF
--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -61,6 +61,17 @@ elif [ $ENVIRONMENT = "us1-fed" ]; then
 # sso_region=us-gov-west-1
 # region=us-gov-west-1
 
+elif [ $ENVIRONMENT = "us2-fed" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
+
+# this role looks like this in ~/.aws/config:
+# [profile sso-govcloud-fed-us2-engineering]
+# sso_start_url=https://start.us-gov-west-1.us-gov-home.awsapps.com/directory/d-98671fdc8b
+# sso_account_id=486696501492
+# sso_role_name=engineering
+# sso_region=us-gov-west-1
+# region=us-gov-west-1
+
     export STAGE="prod"
     if [[ ! "$PACKAGE_NAME" =~ ^datadog_lambda_js-signed-bundle-[0-9]+$ ]]; then
         echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -79,7 +79,7 @@ elif [ $ENVIRONMENT = "us2-fed" ]; then
     fi
 
 else
-    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed or us1-fed.\n"
+    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed, us1-fed, or us2-fed.\n"
     exit 1
 fi
 

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -9,7 +9,7 @@
 # Download button on the `layer bundle` job. This will be a zip file containing
 # all of the required layers. Run this script as follows:
 #
-# ENVIRONMENT=[us1-staging-fed or us1-fed] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
+# ENVIRONMENT=[us1-staging-fed|us1-fed|us2-fed] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
 #
 # protip: you can drag the zip file from finder into your terminal to insert
 # its path.

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -61,14 +61,20 @@ elif [ $ENVIRONMENT = "us1-fed" ]; then
 # sso_region=us-gov-west-1
 # region=us-gov-west-1
 
+  export STAGE="prod"
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_lambda_js-signed-bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
 elif [ $ENVIRONMENT = "us2-fed" ]; then
-    AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
+    AWS_VAULT_ROLE=sso-govcloud-fed-us2-lambda-layer-operator
 
 # this role looks like this in ~/.aws/config:
-# [profile sso-govcloud-fed-us2-engineering]
+# [profile sso-govcloud-fed-us2-lambda-layer-operator]
 # sso_start_url=https://start.us-gov-west-1.us-gov-home.awsapps.com/directory/d-98671fdc8b
 # sso_account_id=486696501492
-# sso_role_name=engineering
+# sso_role_name=lambda-layer-operator
 # sso_region=us-gov-west-1
 # region=us-gov-west-1
 

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -9,7 +9,7 @@
 # Download button on the `layer bundle` job. This will be a zip file containing
 # all of the required layers. Run this script as follows:
 #
-# ENVIRONMENT=[us1-staging-fed|us1-fed|us2-fed] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
+# CI_COMMIT_TAG=<vX.Y.Z> ENVIRONMENT=[us1-staging-fed|us1-fed|us2-fed] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
 #
 # protip: you can drag the zip file from finder into your terminal to insert
 # its path.


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
adds the us2-fed region for govcloud
pending https://github.com/DataDog/cloud-inventory/pull/57908

<!--- A brief description of the change being made with this pull request. --->

### Motivation
[APMSVLS-495](https://datadoghq.atlassian.net/browse/APMSVLS-495)

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
