### PR TITLE
build: support dd-trace package override and filter publish layer check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG image
 FROM $image AS builder
 ARG image
+ARG dd_trace_package
 
 # Create the directory structure required for AWS Lambda Layer
 RUN mkdir -p /nodejs/node_modules/
@@ -8,6 +9,9 @@ RUN mkdir -p /nodejs/node_modules/
 # Install dev dependencies
 COPY . datadog-lambda-js
 WORKDIR /datadog-lambda-js
+RUN if [ -n "$dd_trace_package" ]; then \
+    node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); const spec = process.argv[1]; if (pkg.devDependencies && pkg.devDependencies["dd-trace"]) { pkg.devDependencies["dd-trace"] = spec; } else { pkg.dependencies = pkg.dependencies || {}; pkg.dependencies["dd-trace"] = spec; } fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");' "$dd_trace_package"; \
+    fi
 RUN yarn install
 
 # Build the lambda layer

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -6,6 +6,21 @@
 # Copyright 2019 Datadog, Inc.
 
 # Builds Datadog node layers for lambda functions, using Docker
+#
+# Usage:
+#   NODE_VERSION=20.19 ./scripts/build_layers.sh
+#
+# dd-trace-js overrides (highest priority first):
+#   DD_TRACE_PACKAGE       Exact package spec to use for dd-trace.
+#   DD_TRACE_COMMIT        Specific dd-trace-js commit SHA to build from GitHub.
+#   DD_TRACE_COMMIT_BRANCH dd-trace-js branch name to build from GitHub.
+#
+# Examples:
+#   # Build a single layer for Node 20
+#   NODE_VERSION=20.19 ./scripts/build_layers.sh
+#
+#   # Build a single layer with dd-trace from a branch
+#   DD_TRACE_COMMIT_BRANCH=joey/cross-invocation-tracecontext-propagation NODE_VERSION=20.19 ./scripts/build_layers.sh
 set -e
 
 LAYER_DIR=".layers"
@@ -27,6 +42,21 @@ else
     fi
 fi
 
+function resolve_dd_trace_package {
+    if [ -n "$DD_TRACE_PACKAGE" ]; then
+        echo "$DD_TRACE_PACKAGE"
+    elif [ -n "$DD_TRACE_COMMIT" ]; then
+        echo "git+https://github.com/DataDog/dd-trace-js.git#$DD_TRACE_COMMIT"
+    elif [ -n "$DD_TRACE_COMMIT_BRANCH" ]; then
+        echo "git+https://github.com/DataDog/dd-trace-js.git#$DD_TRACE_COMMIT_BRANCH"
+    fi
+}
+
+DD_TRACE_PACKAGE_SPEC=$(resolve_dd_trace_package)
+if [ -n "$DD_TRACE_PACKAGE_SPEC" ]; then
+    echo "Using dd-trace package spec: $DD_TRACE_PACKAGE_SPEC"
+fi
+
 function make_path_absolute {
     echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 }
@@ -40,7 +70,9 @@ function docker_build_zip {
     # between different node runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-layer-node:$1 . --no-cache \
-        --build-arg image=registry.ddbuild.io/images/mirror/node:${node_image_version}-bullseye --progress=plain -o $temp_dir/nodejs
+        --build-arg image=registry.ddbuild.io/images/mirror/node:${node_image_version}-bullseye \
+        --build-arg dd_trace_package="$DD_TRACE_PACKAGE_SPEC" \
+        --progress=plain -o $temp_dir/nodejs
 
     # Zip to destination, and keep directory structure as based in $temp_dir
     (cd $temp_dir && zip -q -r $destination ./)

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -31,15 +31,6 @@ if [[ ${#LAYER_PATHS[@]} -ne $expected_length ]] || \
     exit 1
 fi
 
-# Check that the layer files exist
-for layer_file in "${LAYER_PATHS[@]}"
-do
-    if [ ! -f $layer_file  ]; then
-        echo "Could not find $layer_file."
-        exit 1
-    fi
-done
-
 # Determine the target regions
 if [ -z "$REGIONS" ]; then
     echo "Region not specified, running for all available regions."
@@ -77,6 +68,19 @@ if [ -z "$VERSION" ]; then
 else
     echo "Layer version specified: $VERSION"
 fi
+
+# Check that the layer files exist for the layers we'll actually publish
+for layer_name in "${LAYERS[@]}"; do
+    for i in "${!AVAILABLE_LAYERS[@]}"; do
+        if [[ "${AVAILABLE_LAYERS[$i]}" = "${layer_name}" ]]; then
+            layer_file="${LAYER_PATHS[$i]}"
+            if [ ! -f "$layer_file" ]; then
+                echo "Could not find $layer_file."
+                exit 1
+            fi
+        fi
+    done
+done
 
 read -p "Ready to publish version $VERSION of layers ${LAYERS[*]} to regions ${REGIONS[*]} (y/n)?" CONT
 if [ "$CONT" != "y" ]; then


### PR DESCRIPTION

## Summary

Two improvements to the layer build/publish flow, mirroring the recent changes to `datadog-lambda-python`:

1. **`scripts/build_layers.sh` + `Dockerfile`** — add the ability to build a layer with an arbitrary `dd-trace` package, useful for git-bisect or testing a feature branch of `dd-trace-js` end-to-end inside the layer. Three new (mutually exclusive, opt-in) env vars on the build script:
   - `DD_TRACE_PACKAGE` — exact package spec passed straight to npm/yarn (e.g. `npm:dd-trace@5.0.0`, `file:./local-tarball.tgz`).
   - `DD_TRACE_COMMIT` — dd-trace-js commit SHA, expanded to `git+https://github.com/DataDog/dd-trace-js.git#<sha>`.
   - `DD_TRACE_COMMIT_BRANCH` — dd-trace-js branch name, expanded the same way.

   The resolved spec is forwarded to docker via `--build-arg dd_trace_package=...`. When none of those env vars are set, the build-arg is empty and the Dockerfile takes its existing path.

2. **`scripts/publish_layers.sh`** — pre-flight check now only requires the zips for layers in `LAYERS`, not all four entries in `LAYER_PATHS`. When `LAYERS` is unset, it still resolves to all available layers, so default invocations behave identically.

## About the Dockerfile change (it's a bit ugly — here's why)

The new step in the Dockerfile is a one-line `node -e '...'` that rewrites `package.json` to swap the `dd-trace` entry over to the override spec, gated on the new build-arg:

```Dockerfile
ARG dd_trace_package
...
RUN if [ -n "$dd_trace_package" ]; then \
    node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); const spec = process.argv[1]; if (pkg.devDependencies && pkg.devDependencies["dd-trace"]) { pkg.devDependencies["dd-trace"] = spec; } else { pkg.dependencies = pkg.dependencies || {}; pkg.dependencies["dd-trace"] = spec; } fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");' "$dd_trace_package"; \
    fi
RUN yarn install
```

It's not pretty, but the alternatives were worse:

- **`yarn add dd-trace@<spec>` instead of editing `package.json`**: `yarn add` triggers a resolve+install during the rewrite step, then `yarn install` runs again on the next layer — duplicate work and a worse-cached image.
- **`sed`/`jq`-based JSON edit**: `sed` on JSON is fragile (formatting, quoting, key ordering); `jq` isn't preinstalled in the node base image.
- **Separate helper script copied in**: would split the override logic across two files instead of keeping it self-contained in the Dockerfile.

Since `node` is guaranteed to exist (it's the layer's whole point), an inline `node -e` rewrite is the most hermetic option even if the one-liner reads rough. The `if` guard means the entire branch is dead code in default builds.

The script also handles a quirk of the current `package.json`: `dd-trace` lives in `devDependencies` (because `yarn` packs it into the layer build, not at runtime) — so we update it in place if it's already there, and only fall back to writing into `dependencies` if it isn't. That preserves the existing dev-vs-prod placement.

## Backwards compatibility

- No new env vars set → `DD_TRACE_PACKAGE_SPEC` is empty → build-arg is empty → Dockerfile `if` is false → identical to today.
- `LAYERS` unset on publish → still requires all 4 zips.
- `Dockerfile` change is a no-op unless the new build-arg is non-empty.

## Test plan

- [x] `DD_TRACE_COMMIT_BRANCH=<branch> NODE_VERSION=20.19 ./scripts/build_layers.sh` produces a layer that uses the override.
- [x] `VERSION=N REGIONS=us-east-2 LAYERS=Datadog-Node20-x ./scripts/publish_layers.sh` proceeds with only the matching zip built.
- [x] Default `./scripts/build_layers.sh` (no override env vars) builds layers byte-identical to current behavior.
