### PR TITLE
[SVLS-8538] feat: rename durable function span tags to aws.durable.*

### DIFF
--- a/src/trace/durable-function-context.spec.ts
+++ b/src/trace/durable-function-context.spec.ts
@@ -60,9 +60,9 @@ describe("durable-function-context", () => {
       const result = extractDurableFunctionContext(event);
 
       expect(result).toEqual({
-        "aws_lambda.durable_function.execution_name": "my-execution",
-        "aws_lambda.durable_function.execution_id": "550e8400-e29b-41d4-a716-446655440004",
-        "aws_lambda.durable_function.first_invocation": "false",
+        "aws.durable.execution_name": "my-execution",
+        "aws.durable.execution_id": "550e8400-e29b-41d4-a716-446655440004",
+        "aws.durable.first_invocation": "false",
       });
     });
 
@@ -76,7 +76,7 @@ describe("durable-function-context", () => {
       };
       const result = extractDurableFunctionContext(event);
 
-      expect(result?.["aws_lambda.durable_function.first_invocation"]).toBe("true");
+      expect(result?.["aws.durable.first_invocation"]).toBe("true");
     });
 
     it("sets first_invocation to false when Operations has more than one entry", () => {
@@ -89,7 +89,7 @@ describe("durable-function-context", () => {
       };
       const result = extractDurableFunctionContext(event);
 
-      expect(result?.["aws_lambda.durable_function.first_invocation"]).toBe("false");
+      expect(result?.["aws.durable.first_invocation"]).toBe("false");
     });
 
     it("omits first_invocation when InitialExecutionState is absent", () => {
@@ -100,7 +100,7 @@ describe("durable-function-context", () => {
       const result = extractDurableFunctionContext(event);
 
       expect(result).toBeDefined();
-      expect(result?.["aws_lambda.durable_function.first_invocation"]).toBeUndefined();
+      expect(result?.["aws.durable.first_invocation"]).toBeUndefined();
     });
 
     it("returns undefined for regular Lambda event without DurableExecutionArn", () => {

--- a/src/trace/durable-function-context.ts
+++ b/src/trace/durable-function-context.ts
@@ -1,9 +1,9 @@
 import { logDebug } from "../utils";
 
 export interface DurableFunctionContext {
-  "aws_lambda.durable_function.execution_name": string;
-  "aws_lambda.durable_function.execution_id": string;
-  "aws_lambda.durable_function.first_invocation"?: string;
+  "aws.durable.execution_name": string;
+  "aws.durable.execution_id": string;
+  "aws.durable.first_invocation"?: string;
 }
 
 const VALID_DURABLE_EXECUTION_STATUSES = new Set(["SUCCEEDED", "FAILED", "PENDING"]);
@@ -22,14 +22,14 @@ export function extractDurableFunctionContext(event: any): DurableFunctionContex
   }
 
   const context: DurableFunctionContext = {
-    "aws_lambda.durable_function.execution_name": parsed.executionName,
-    "aws_lambda.durable_function.execution_id": parsed.executionId,
+    "aws.durable.execution_name": parsed.executionName,
+    "aws.durable.execution_id": parsed.executionId,
   };
 
   // Use the number of operations to determine if it's the first invocation.
   const operations = event?.InitialExecutionState?.Operations;
   if (Array.isArray(operations)) {
-    context["aws_lambda.durable_function.first_invocation"] = String(operations.length === 1);
+    context["aws.durable.first_invocation"] = String(operations.length === 1);
   }
 
   return context;

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -560,10 +560,7 @@ describe("TraceListener", () => {
       listener.onEndingInvocation(durableEvent, {}, false);
 
       expect(mockSetTag).toHaveBeenCalledWith("aws.durable.execution_name", "my-execution");
-      expect(mockSetTag).toHaveBeenCalledWith(
-        "aws.durable.execution_id",
-        "550e8400-e29b-41d4-a716-446655440004",
-      );
+      expect(mockSetTag).toHaveBeenCalledWith("aws.durable.execution_id", "550e8400-e29b-41d4-a716-446655440004");
     } finally {
       currentSpanSpy.mockRestore();
     }

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -559,9 +559,9 @@ describe("TraceListener", () => {
       await listener.onStartInvocation(durableEvent, context as any);
       listener.onEndingInvocation(durableEvent, {}, false);
 
-      expect(mockSetTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_name", "my-execution");
+      expect(mockSetTag).toHaveBeenCalledWith("aws.durable.execution_name", "my-execution");
       expect(mockSetTag).toHaveBeenCalledWith(
-        "aws_lambda.durable_function.execution_id",
+        "aws.durable.execution_id",
         "550e8400-e29b-41d4-a716-446655440004",
       );
     } finally {
@@ -583,7 +583,7 @@ describe("TraceListener", () => {
       await listener.onStartInvocation(durableEvent, context as any);
       listener.onEndingInvocation(durableEvent, { Status: "SUCCEEDED" }, false);
 
-      expect(mockSetTag).toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", "SUCCEEDED");
+      expect(mockSetTag).toHaveBeenCalledWith("aws.durable.execution_status", "SUCCEEDED");
     } finally {
       currentSpanSpy.mockRestore();
     }
@@ -603,7 +603,7 @@ describe("TraceListener", () => {
       await listener.onStartInvocation(durableEvent, context as any);
       listener.onEndingInvocation(durableEvent, { Status: "UNKNOWN" }, false);
 
-      expect(mockSetTag).not.toHaveBeenCalledWith("aws_lambda.durable_function.execution_status", expect.anything());
+      expect(mockSetTag).not.toHaveBeenCalledWith("aws.durable.execution_status", expect.anything());
     } finally {
       currentSpanSpy.mockRestore();
     }

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -240,7 +240,7 @@ export class TraceListener {
     }
     const executionStatus = extractDurableExecutionStatus(event, result);
     if (executionStatus !== undefined) {
-      this.tracerWrapper.currentSpan.setTag("aws_lambda.durable_function.execution_status", executionStatus);
+      this.tracerWrapper.currentSpan.setTag("aws.durable.execution_status", executionStatus);
     }
 
     let rootSpan = this.inferredSpan;


### PR DESCRIPTION
## Summary
- Rename span tags on the `aws.lambda` span from `aws_lambda.durable_function.*` to `aws.durable.*`.
- Affected tags: `execution_name`, `execution_id`, `first_invocation`, `execution_status`.

## Motivation
Suggested by @joeyzhao2018 and @pablomartinezbernardo . Slack: https://dd.slack.com/archives/C09N4B181G9/p1779297316670489

## Test plan
- [x] `yarn jest src/trace/durable-function-context.spec.ts src/trace/listener.spec.ts` — 37/37 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)