### PR TITLE
Release/v12.139.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,22 @@ RUN yarn install
 RUN yarn build
 RUN cp -r dist /nodejs/node_modules/datadog-lambda-js
 RUN cp ./src/runtime/module_importer.js /nodejs/node_modules/datadog-lambda-js/runtime
+RUN node <<'EOF'
+const fs = require("fs");
+const { name, version } = require("./package.json");
+
+const layerPackage = {
+  name,
+  version,
+  main: "index.js",
+  types: "index.d.ts",
+};
+
+fs.writeFileSync(
+  "/nodejs/node_modules/datadog-lambda-js/package.json",
+  `${JSON.stringify(layerPackage, null, 2)}\n`,
+);
+EOF
 
 RUN cp ./src/handler.mjs /nodejs/node_modules/datadog-lambda-js
 RUN rm -rf node_modules

--- a/integration_tests/snapshots/logs/esm_node18.log
+++ b/integration_tests/snapshots/logs/esm_node18.log
@@ -24,8 +24,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -44,8 +47,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -57,9 +60,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -67,14 +68,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -97,9 +100,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -130,9 +131,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -151,8 +155,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -165,9 +169,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -175,14 +177,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -202,9 +206,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -235,9 +237,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -256,8 +261,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -270,9 +275,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -280,14 +283,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -307,9 +312,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -340,9 +343,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -361,8 +367,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -375,9 +381,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -385,14 +389,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -412,9 +418,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -445,9 +449,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -465,8 +472,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -479,9 +486,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -489,14 +494,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -516,9 +523,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -549,9 +554,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -569,8 +577,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -583,9 +591,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -593,14 +599,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -620,9 +628,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -653,9 +659,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -673,8 +682,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -687,9 +696,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -697,14 +704,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -724,9 +733,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -757,8 +764,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,14 +808,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -827,9 +837,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -860,8 +868,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -878,8 +889,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -892,9 +903,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -902,14 +911,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node18",
+        "service": "integration-tests-js-XXXX-esm_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -929,9 +940,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/esm_node20.log
+++ b/integration_tests/snapshots/logs/esm_node20.log
@@ -24,8 +24,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -44,8 +47,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -57,9 +60,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -67,14 +68,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -97,9 +100,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -130,9 +131,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -151,8 +155,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -165,9 +169,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -175,14 +177,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -202,9 +206,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -235,9 +237,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -256,8 +261,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -270,9 +275,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -280,14 +283,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -307,9 +312,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -340,9 +343,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -361,8 +367,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -375,9 +381,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -385,14 +389,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -412,9 +418,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -445,9 +449,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -465,8 +472,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -479,9 +486,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -489,14 +494,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -516,9 +523,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -549,9 +554,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -569,8 +577,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -583,9 +591,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -593,14 +599,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -620,9 +628,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -653,9 +659,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -673,8 +682,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -687,9 +696,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -697,14 +704,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -724,9 +733,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -757,8 +764,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,14 +808,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -827,9 +837,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -860,8 +868,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -878,8 +889,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -892,9 +903,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -902,14 +911,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node20",
+        "service": "integration-tests-js-XXXX-esm_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -929,9 +940,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/esm_node22.log
+++ b/integration_tests/snapshots/logs/esm_node22.log
@@ -24,8 +24,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -44,8 +47,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -57,9 +60,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -67,14 +68,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -97,9 +100,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -130,9 +131,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -151,8 +155,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -165,9 +169,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -175,14 +177,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -202,9 +206,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -235,9 +237,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -256,8 +261,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -270,9 +275,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -280,14 +283,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -307,9 +312,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -340,9 +343,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -361,8 +367,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -375,9 +381,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -385,14 +389,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -412,9 +418,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -445,9 +449,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -465,8 +472,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -479,9 +486,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -489,14 +494,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -516,9 +523,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -549,9 +554,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -569,8 +577,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -583,9 +591,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -593,14 +599,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -620,9 +628,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -653,9 +659,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -673,8 +682,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -687,9 +696,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -697,14 +704,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -724,9 +733,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -757,8 +764,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,14 +808,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -827,9 +837,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -860,8 +868,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -878,8 +889,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -892,9 +903,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -902,14 +911,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node22",
+        "service": "integration-tests-js-XXXX-esm_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -929,9 +940,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/esm_node24.log
+++ b/integration_tests/snapshots/logs/esm_node24.log
@@ -24,8 +24,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -44,8 +47,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -57,9 +60,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -67,14 +68,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -97,9 +100,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -130,9 +131,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -151,8 +155,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -165,9 +169,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -175,14 +177,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -202,9 +206,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -235,9 +237,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -256,8 +261,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -270,9 +275,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -280,14 +283,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -307,9 +312,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -340,9 +343,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -361,8 +367,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -375,9 +381,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -385,14 +389,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -412,9 +418,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -445,9 +449,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -465,8 +472,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -479,9 +486,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -489,14 +494,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -516,9 +523,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -549,9 +554,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -569,8 +577,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -583,9 +591,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -593,14 +599,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -620,9 +628,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -653,9 +659,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -673,8 +682,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -687,9 +696,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -697,14 +704,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -724,9 +733,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -757,8 +764,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,14 +808,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -827,9 +837,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -860,8 +868,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "_dd.origin": "lambda",
@@ -878,8 +889,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-esm_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-esm_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -892,9 +903,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -902,14 +911,16 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-esm_node24",
+        "service": "integration-tests-js-XXXX-esm_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
           "_dd.origin": "lambda",
-          "service": "integration-tests-js-XXXX-esm_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-esm_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -929,9 +940,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-esm_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/process-input-traced_node18.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node18.log
@@ -33,8 +33,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -52,8 +55,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -65,9 +68,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -75,13 +76,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -106,9 +109,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -116,10 +117,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -131,8 +133,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -140,10 +141,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
@@ -157,8 +159,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -198,9 +199,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -218,8 +222,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -232,9 +236,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -242,13 +244,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -268,9 +272,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -278,10 +280,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -293,8 +296,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -302,10 +304,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -317,8 +320,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -358,9 +360,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -378,8 +383,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -392,9 +397,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -402,13 +405,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -428,9 +433,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -438,10 +441,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -453,8 +457,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -462,10 +465,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -477,8 +481,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -518,9 +521,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -538,8 +544,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -552,9 +558,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -562,13 +566,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -588,9 +594,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -598,10 +602,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -613,8 +618,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -622,10 +626,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -637,8 +642,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -678,9 +682,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -697,8 +704,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -711,9 +718,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -721,13 +726,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -748,9 +755,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -758,10 +763,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/multipart_object.txt",
@@ -775,8 +781,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -816,9 +821,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -835,8 +843,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -849,9 +857,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -859,13 +865,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -886,9 +894,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -896,10 +902,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/copied_object.txt",
@@ -913,8 +920,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -954,9 +960,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -973,8 +982,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -987,9 +996,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -997,13 +1004,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1024,9 +1033,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1034,10 +1041,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/test_object.txt",
@@ -1051,8 +1059,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -1092,8 +1099,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -1111,8 +1121,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -1124,9 +1134,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1134,13 +1142,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1161,9 +1171,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1171,10 +1179,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "record_event_type": "SNS",
           "record_ids":"XXXX",
@@ -1188,8 +1197,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]
@@ -1229,8 +1237,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -1246,8 +1257,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -1260,9 +1271,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1270,13 +1279,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node18",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1297,9 +1308,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1307,10 +1316,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node18",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node18",
           "runtime-id":"XXXX",
           "record_event_type": "SQS",
           "record_ids":"XXXX,2e1424d4-f796-459a-8184-9c92662be6da",
@@ -1324,8 +1334,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node18"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/process-input-traced_node20.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node20.log
@@ -33,8 +33,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -52,8 +55,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -65,9 +68,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -75,13 +76,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -106,9 +109,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -116,10 +117,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -131,8 +133,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -140,10 +141,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
@@ -157,8 +159,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -198,9 +199,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -218,8 +222,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -232,9 +236,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -242,13 +244,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -268,9 +272,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -278,10 +280,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -293,8 +296,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -302,10 +304,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -317,8 +320,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -358,9 +360,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -378,8 +383,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -392,9 +397,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -402,13 +405,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -428,9 +433,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -438,10 +441,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -453,8 +457,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -462,10 +465,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -477,8 +481,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -518,9 +521,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -538,8 +544,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -552,9 +558,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -562,13 +566,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -588,9 +594,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -598,10 +602,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -613,8 +618,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -622,10 +626,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -637,8 +642,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -678,9 +682,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -697,8 +704,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -711,9 +718,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -721,13 +726,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -748,9 +755,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -758,10 +763,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/multipart_object.txt",
@@ -775,8 +781,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -816,9 +821,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -835,8 +843,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -849,9 +857,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -859,13 +865,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -886,9 +894,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -896,10 +902,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/copied_object.txt",
@@ -913,8 +920,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -954,9 +960,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -973,8 +982,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -987,9 +996,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -997,13 +1004,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1024,9 +1033,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1034,10 +1041,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/test_object.txt",
@@ -1051,8 +1059,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -1092,8 +1099,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -1111,8 +1121,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -1124,9 +1134,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1134,13 +1142,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1161,9 +1171,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1171,10 +1179,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "record_event_type": "SNS",
           "record_ids":"XXXX",
@@ -1188,8 +1197,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]
@@ -1229,8 +1237,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -1246,8 +1257,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -1260,9 +1271,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1270,13 +1279,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node20",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1297,9 +1308,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1307,10 +1316,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node20",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node20",
           "runtime-id":"XXXX",
           "record_event_type": "SQS",
           "record_ids":"XXXX,2e1424d4-f796-459a-8184-9c92662be6da",
@@ -1324,8 +1334,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node20"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/process-input-traced_node22.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node22.log
@@ -33,8 +33,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -52,8 +55,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -65,9 +68,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -75,13 +76,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -106,9 +109,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -116,10 +117,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -131,8 +133,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -140,10 +141,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
@@ -157,8 +159,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
@@ -198,9 +199,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -218,8 +222,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -232,9 +236,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -242,13 +244,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -268,9 +272,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -278,10 +280,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -293,8 +296,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -302,10 +304,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -317,8 +320,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
@@ -358,9 +360,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -378,8 +383,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -392,9 +397,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -402,13 +405,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -428,9 +433,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -438,10 +441,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -453,8 +457,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -462,10 +465,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -477,8 +481,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
@@ -518,9 +521,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -538,8 +544,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -552,9 +558,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -562,13 +566,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -588,9 +594,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -598,10 +602,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -613,8 +618,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -622,10 +626,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -637,14 +642,14 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
+END Duration: XXXX ms Memory Used: XXXX MB
 {
   "e": XXXX,
   "m": "aws.lambda.enhanced.invocations",
@@ -678,9 +683,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -697,8 +705,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -711,9 +719,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -721,13 +727,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -748,9 +756,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -758,10 +764,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/multipart_object.txt",
@@ -775,13 +782,11 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
 }
-END Duration: XXXX ms Memory Used: XXXX MB
 START
 {
   "e": XXXX,
@@ -816,9 +821,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -835,8 +843,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -849,9 +857,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -859,13 +865,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -886,9 +894,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -896,10 +902,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/copied_object.txt",
@@ -913,8 +920,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
@@ -954,9 +960,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -973,8 +982,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -987,9 +996,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -997,13 +1004,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1024,9 +1033,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1034,10 +1041,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/test_object.txt",
@@ -1051,8 +1059,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
@@ -1092,8 +1099,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -1111,8 +1121,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -1124,9 +1134,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1134,13 +1142,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1161,9 +1171,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1171,10 +1179,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "record_event_type": "SNS",
           "record_ids":"XXXX",
@@ -1188,8 +1197,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]
@@ -1229,8 +1237,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -1246,8 +1257,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -1260,9 +1271,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1270,13 +1279,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node22",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1297,9 +1308,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1307,10 +1316,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node22",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node22",
           "runtime-id":"XXXX",
           "record_event_type": "SQS",
           "record_ids":"XXXX,2e1424d4-f796-459a-8184-9c92662be6da",
@@ -1324,8 +1334,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node22"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/process-input-traced_node24.log
+++ b/integration_tests/snapshots/logs/process-input-traced_node24.log
@@ -33,8 +33,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -52,8 +55,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "200",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -65,9 +68,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -75,13 +76,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -106,9 +109,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -116,10 +117,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -131,8 +133,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -140,10 +141,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "api_gateway_request_id": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
           "event_type": "APIGateway",
@@ -157,8 +159,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -198,9 +199,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -218,8 +222,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -232,9 +236,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -242,13 +244,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -268,9 +272,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -278,10 +280,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -293,8 +296,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -302,10 +304,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -317,8 +320,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -358,9 +360,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -378,8 +383,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -392,9 +397,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -402,13 +405,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -428,9 +433,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -438,10 +441,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -453,8 +457,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -462,10 +465,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -477,8 +481,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -518,9 +521,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -538,8 +544,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -552,9 +558,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -562,13 +566,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -588,9 +594,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -598,10 +602,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -613,8 +618,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -622,10 +626,11 @@ START
         "parent_id":"XXXX",
         "name": "getAPIGatewayRequestId",
         "resource": "getAPIGatewayRequestId",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "_dd.integration": "opentracing",
           "language": "javascript"
@@ -637,8 +642,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -678,9 +682,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -697,8 +704,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -711,9 +718,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -721,13 +726,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -748,9 +755,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -758,10 +763,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/multipart_object.txt",
@@ -775,8 +781,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -816,9 +821,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -835,8 +843,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -849,9 +857,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -859,13 +865,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -886,9 +894,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -896,10 +902,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/copied_object.txt",
@@ -913,8 +920,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -954,9 +960,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -973,8 +982,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -987,9 +996,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -997,13 +1004,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1024,9 +1033,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1034,10 +1041,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "record_event_type": "S3",
           "record_ids":"XXXX/test_object.txt",
@@ -1051,8 +1059,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -1092,8 +1099,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -1111,8 +1121,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -1124,9 +1134,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1134,13 +1142,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1161,9 +1171,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1171,10 +1179,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "record_event_type": "SNS",
           "record_ids":"XXXX",
@@ -1188,8 +1197,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]
@@ -1229,8 +1237,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -1246,8 +1257,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-process-input-traced_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-process-input-traced_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -1260,9 +1271,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1270,13 +1279,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-process-input-traced_node24",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -1297,9 +1308,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24",
-        "type": "serverless"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -1307,10 +1316,11 @@ START
         "parent_id":"XXXX",
         "name": "getRecordIds",
         "resource": "getRecordIds",
+        "service": "integration-tests-js-XXXX-process-input-traced_node24",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-process-input-traced_node24",
           "runtime-id":"XXXX",
           "record_event_type": "SQS",
           "record_ids":"XXXX,2e1424d4-f796-459a-8184-9c92662be6da",
@@ -1324,8 +1334,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-process-input-traced_node24"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/status-code-500s_node18.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node18.log
@@ -39,8 +39,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -58,8 +61,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "500",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -71,9 +74,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -81,13 +82,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 1,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -110,9 +113,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -143,9 +144,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -163,8 +167,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -177,9 +181,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -187,13 +189,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -213,9 +217,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -246,9 +248,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -266,8 +271,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -280,9 +285,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -290,13 +293,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -316,9 +321,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -349,9 +352,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -369,8 +375,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -383,9 +389,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -393,13 +397,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -419,9 +425,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -452,9 +456,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -471,8 +478,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -485,9 +492,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -495,13 +500,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -521,9 +528,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -554,9 +559,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -573,8 +581,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -587,9 +595,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -597,13 +603,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -623,9 +631,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -656,9 +662,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -675,8 +684,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -689,9 +698,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -699,13 +706,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -725,9 +734,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -758,8 +765,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,13 +808,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -826,9 +836,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -859,8 +867,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -876,8 +887,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node18",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node18",
           "language": "javascript"
         },
         "metrics": {
@@ -890,9 +901,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -900,13 +909,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node18",
+        "service": "integration-tests-js-XXXX-status-code-500s_node18",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node18",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node18",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -926,9 +937,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node18",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/status-code-500s_node20.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node20.log
@@ -39,8 +39,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -58,8 +61,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "500",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -71,9 +74,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -81,13 +82,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 1,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -110,9 +113,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -143,9 +144,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -163,8 +167,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -177,9 +181,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -187,13 +189,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -213,9 +217,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -246,9 +248,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -266,8 +271,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -280,9 +285,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -290,13 +293,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -316,9 +321,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -349,9 +352,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -369,8 +375,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -383,9 +389,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -393,13 +397,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -419,9 +425,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -452,9 +456,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -471,8 +478,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -485,9 +492,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -495,13 +500,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -521,9 +528,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -554,9 +559,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -573,8 +581,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -587,9 +595,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -597,13 +603,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -623,9 +631,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -656,9 +662,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -675,8 +684,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -689,9 +698,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -699,13 +706,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -725,9 +734,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -758,8 +765,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,13 +808,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -826,9 +836,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -859,8 +867,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -876,8 +887,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node20",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node20",
           "language": "javascript"
         },
         "metrics": {
@@ -890,9 +901,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -900,13 +909,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node20",
+        "service": "integration-tests-js-XXXX-status-code-500s_node20",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node20",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node20",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -926,9 +937,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node20",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/status-code-500s_node22.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node22.log
@@ -39,8 +39,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -58,8 +61,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "500",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -71,9 +74,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -81,13 +82,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 1,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -110,9 +113,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -143,9 +144,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -163,8 +167,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -177,9 +181,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -187,13 +189,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -213,9 +217,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -246,9 +248,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -266,8 +271,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -280,9 +285,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -290,13 +293,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -316,9 +321,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -349,9 +352,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -369,8 +375,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -383,9 +389,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -393,13 +397,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -419,9 +425,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -452,9 +456,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -471,8 +478,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -485,9 +492,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -495,13 +500,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -521,9 +528,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -554,9 +559,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -573,8 +581,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -587,9 +595,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -597,13 +603,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -623,16 +631,13 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
 }
 END Duration: XXXX ms Memory Used: XXXX MB
 START
-END Duration: XXXX ms Memory Used: XXXX MB
 {
   "e": XXXX,
   "m": "aws.lambda.enhanced.invocations",
@@ -657,9 +662,12 @@ END Duration: XXXX ms Memory Used: XXXX MB
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -676,8 +684,8 @@ END Duration: XXXX ms Memory Used: XXXX MB
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -690,9 +698,7 @@ END Duration: XXXX ms Memory Used: XXXX MB
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -700,13 +706,15 @@ END Duration: XXXX ms Memory Used: XXXX MB
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -726,13 +734,12 @@ END Duration: XXXX ms Memory Used: XXXX MB
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
 }
+END Duration: XXXX ms Memory Used: XXXX MB
 START
 {
   "e": XXXX,
@@ -758,8 +765,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,13 +808,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -826,9 +836,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -859,8 +867,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -876,8 +887,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node22",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node22",
           "language": "javascript"
         },
         "metrics": {
@@ -890,9 +901,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -900,13 +909,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node22",
+        "service": "integration-tests-js-XXXX-status-code-500s_node22",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node22",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node22",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -926,9 +937,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node22",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/integration_tests/snapshots/logs/status-code-500s_node24.log
+++ b/integration_tests/snapshots/logs/status-code-500s_node24.log
@@ -39,8 +39,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.apigateway",
         "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedApiGatewayServiceName",
@@ -58,8 +61,8 @@ START
           "dd_resource_key": "arn:aws:apigateway:eu-west-1::/restapis/wt6mne2s9k",
           "http.status_code": "500",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -71,9 +74,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedApiGatewayServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -81,13 +82,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 1,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "true",
           "span.kind": "server",
+          "cold_start": "true",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -110,9 +113,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -143,9 +144,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -163,8 +167,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -177,9 +181,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -187,13 +189,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -213,9 +217,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -246,9 +248,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -266,8 +271,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -280,9 +285,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -290,13 +293,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -316,9 +321,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -349,9 +352,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.dynamodb",
         "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedDynamoDbServiceName",
@@ -369,8 +375,8 @@ START
           "event_id": "0123456789abcdef09123456789abcdef",
           "stream_view_type": "KEYS_ONLY",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -383,9 +389,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedDynamoDbServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -393,13 +397,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -419,9 +425,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -452,9 +456,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -471,8 +478,8 @@ START
           "object_key": "multipart_object.txt",
           "object_etag": "09876543210987654321098765432109-2",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -485,9 +492,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -495,13 +500,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -521,9 +528,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -554,9 +559,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -573,8 +581,8 @@ START
           "object_key": "copied_object.txt",
           "object_etag": "01234567890123456789012345678901",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -587,9 +595,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -597,13 +603,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -623,9 +631,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -656,9 +662,12 @@ START
         "parent_id":"XXXX",
         "name": "aws.s3",
         "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
           "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedS3ServiceName",
@@ -675,8 +684,8 @@ START
           "object_key": "test_object.txt",
           "object_etag": "abcdef0123456789abcdef01234567890",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -689,9 +698,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedS3ServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -699,13 +706,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -725,9 +734,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -758,8 +765,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sns",
         "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSnsServiceName",
@@ -777,8 +787,8 @@ START
           "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
           "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -790,9 +800,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSnsServiceName",
-        "type": "sns"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -800,13 +808,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -826,9 +836,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]
@@ -859,8 +867,11 @@ START
         "parent_id":"XXXX",
         "name": "aws.sqs",
         "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
         "error": 0,
         "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "_dd.p.tid": "XXXX",
           "_dd.p.dm": "-0",
           "service": "remappedSqsServiceName",
@@ -876,8 +887,8 @@ START
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
           "_dd.base_service": "integration-tests-js-XXXX-status-code-500s_node24",
-          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:integration_tests,svc.auto:integration-tests-js-XXXX-status-code-500s_node24",
           "language": "javascript"
         },
         "metrics": {
@@ -890,9 +901,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "remappedSqsServiceName",
-        "type": "web"
+        "links": []
       },
       {
         "trace_id":"XXXX",
@@ -900,13 +909,15 @@ START
         "parent_id":"XXXX",
         "name": "aws.lambda",
         "resource": "integration-tests-js-XXXX-status-code-500s_node24",
+        "service": "integration-tests-js-XXXX-status-code-500s_node24",
+        "type": "serverless",
         "error": 0,
         "meta": {
-          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "version": "1.0.0",
+          "service": "integration-tests-js-XXXX-status-code-500s_node24",
           "runtime-id":"XXXX",
-          "cold_start": "false",
           "span.kind": "server",
+          "cold_start": "false",
           "function_arn":"XXXX_node24",
           "function_version": "$LATEST",
           "request_id":"XXXX",
@@ -926,9 +937,7 @@ START
         },
         "start":XXXX,
         "duration":XXXX,
-        "links": [],
-        "service": "integration-tests-js-XXXX-status-code-500s_node24",
-        "type": "serverless"
+        "links": []
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^20.12.10",
     "@types/promise-retry": "^1.1.3",
     "@types/shimmer": "^1.0.1",
-    "dd-trace": "^5.93.0",
+    "dd-trace": "^5.105.0",
     "jest": "^27.0.1",
     "mock-fs": "4.14.0",
     "nock": "13.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "12.138.0",
+  "version": "12.139.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,17 +1144,17 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@datadog/flagging-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/flagging-core/-/flagging-core-1.1.0.tgz#c053bace953c3326fd5a75f1879cfd7e2d2a1db4"
-  integrity sha512-m2BSEmdSd4P5c/l+4C2L32vnnhwr0bF3qnM2Uz0NhWbUxX4SjpUHbb7GPq8bjr0rfZJZefQ7zQjN/cjE+bb7pg==
+"@datadog/flagging-core@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@datadog/flagging-core/-/flagging-core-1.2.1.tgz#1bb2d1ecfd749033ed2570eccc8fb0697b8adfac"
+  integrity sha512-qeDkki9fFlqyoZBrn7tneT6pZ04EKKvf3xxisYw1a74zbJihvQui/ARUsjXCurRpzpFqGGTJw/oz+HnXaKhcdw==
   dependencies:
     spark-md5 "^3.0.2"
 
-"@datadog/libdatadog@0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.9.2.tgz#d7a0193ab656bd9cc40649f300ef6c54d9bea52d"
-  integrity sha512-grOerTYuU3wHuFIOBGg3jB144A3KEthEdVEL3meeiXYo7E7fBXXGRgAOwVE42VXFXfl0r8kDKCL7KupBc511tg==
+"@datadog/libdatadog@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.9.3.tgz#c9a26946e1f4a750889594790b3434070997b8fa"
+  integrity sha512-L+scIlcRRRF0qjeSU3VQLQlqezfQHkDdnOdbmx/gLjPqewKSyqVGp7XRdKXYo2vZTzmG8dH6rPKXwgI68UQufw==
 
 "@datadog/native-appsec@11.0.1":
   version "11.0.1"
@@ -1163,27 +1163,27 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-taint-tracking@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.1.0.tgz#133d1b5530f60aec4875fda8d7b07a2fc1a8deb0"
-  integrity sha512-g9K9Ddx1YQfrQIC2hgtfnYUGuzAFvSvhvt2lPZOAWBPo+bkYoW5KEkMHoY5XykCigTfXBYcQicRV0xB22AMkHw==
+"@datadog/native-iast-taint-tracking@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.2.0.tgz#ca05a1510af130e14fad7721b539dcf151ee235f"
+  integrity sha512-NpZABJQoNMzF6cU521RT4GQ8/FbfFRoDepOLTcLYKyw0DY2WmSpg3iG+PoQNK4O3jPSXC++K3rg59GiQgA3Mog==
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-metrics@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.1.1.tgz#4e5c9775751af13e353e64e573ab724104538cee"
-  integrity sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==
+"@datadog/native-metrics@3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.1.2.tgz#9dc269bdbc6f5b5c9a30dc6d99bab44d17dd5a37"
+  integrity sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==
   dependencies:
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/openfeature-node-server@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/openfeature-node-server/-/openfeature-node-server-1.1.0.tgz#d6f5e74408690d2bf2bead5def8145690ec2cf86"
-  integrity sha512-Qy5sz6vGq3KekoRLw9zko7LsDd97MPjJSnYl7jUq7bMST5p0aFFh/MnILn9/B1UC7RZJ6Kj5F2U0hxqmAWz2dw==
+"@datadog/openfeature-node-server@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz#762b39e486f9d04e0219058b1b9b4202004cf091"
+  integrity sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==
   dependencies:
-    "@datadog/flagging-core" "1.1.0"
+    "@datadog/flagging-core" "^1.2.1"
 
 "@datadog/pprof@*":
   version "5.13.2"
@@ -1196,12 +1196,12 @@
     pprof-format "^2.2.1"
     source-map "^0.7.4"
 
-"@datadog/pprof@5.14.0":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.14.0.tgz#a5a43fde3ca9369345994cc5cf82d5dcf743fb1c"
-  integrity sha512-bXYptMf0BY3NdKcAmX5aAOnozj7GFdNYE4SIdPF0/Q/Yfb2fYBIYZaN/Le6BhiDIepBvvH/H75d3EIFhB64kOw==
+"@datadog/pprof@5.14.4":
+  version "5.14.4"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.14.4.tgz#4a242b6e9c78f66aff836e926b28733749cfa83b"
+  integrity sha512-egEZDD9v98RBI8ijbHyaWQeY8rW0WEu004As5D7SUkdqSMORhrnh7ZdsM46PUzQgAc85IaEZoukWS9UhMvWn9w==
   dependencies:
-    node-gyp-build "<4.0"
+    node-gyp-build "^4.8.4"
     pprof-format "^2.2.1"
     source-map "^0.7.4"
 
@@ -1215,25 +1215,25 @@
     module-details-from-path "^1.0.3"
     node-gyp-build "^4.5.0"
 
-"@emnapi/core@^1.7.1":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.0.tgz#4a54213b208fcf288cce25076c74e0f7613e6100"
-  integrity sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==
+"@emnapi/core@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
   dependencies:
-    "@emnapi/wasi-threads" "1.2.0"
+    "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
-"@emnapi/runtime@^1.7.1":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.0.tgz#91c54a6e77c36154c125e873409472e2b70efd5b"
-  integrity sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==
+"@emnapi/runtime@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/wasi-threads@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
-  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
+"@emnapi/wasi-threads@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
   dependencies:
     tslib "^2.4.0"
 
@@ -1454,13 +1454,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@napi-rs/wasm-runtime@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
-  integrity sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==
+"@napi-rs/wasm-runtime@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
+  integrity sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==
   dependencies:
-    "@emnapi/core" "^1.7.1"
-    "@emnapi/runtime" "^1.7.1"
     "@tybys/wasm-util" "^0.10.1"
 
 "@opentelemetry/api-logs@*", "@opentelemetry/api-logs@<1.0.0":
@@ -1475,112 +1473,114 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@oxc-parser/binding-android-arm-eabi@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.118.0.tgz#5c5f6230d6a5bbd7389523fb5fcaf7f0860ced56"
-  integrity sha512-u/fO8WrQ5xiXXe2bCUmiihDaZQi0rvMxBtvPv7/lyQDBcfR81/usWv4ZMaKHkWOUXDoOBw1ptHi+A8+/zWGLGA==
+"@oxc-parser/binding-android-arm-eabi@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz#f88d600252349b5e380e695cadf889cea896f676"
+  integrity sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==
 
-"@oxc-parser/binding-android-arm64@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.118.0.tgz#65fd57ea05b90a0b0086b01b58af54ffc2d8ffce"
-  integrity sha512-hHUdc9RNh/cDBIyUExTRrGZXlrpcc4W+co+JwH4aR2rBB9Y6Zjsx9tSVdIn9HBF1ZBpOV7XgeZKnqRHNvbEPNw==
+"@oxc-parser/binding-android-arm64@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz#ef91deec0305c54fa6c7b519f82da63d36b49788"
+  integrity sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==
 
-"@oxc-parser/binding-darwin-arm64@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.118.0.tgz#9f2cfcd83641b03232de1c4b512bcffdeaa7660d"
-  integrity sha512-LHlbZxiUBHdaSmgOTIdkd5WzTddwUGJXjTX5AdvUIC0640z6xP7AQQE46X6FokOKu/PZKM0RegB2MWr2+0kakA==
+"@oxc-parser/binding-darwin-arm64@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz#033a8f2789c3d09509ddd1a219dcbf2fd516125f"
+  integrity sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==
 
-"@oxc-parser/binding-darwin-x64@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.118.0.tgz#c01375cd9cdbf5b3a0da801190a88643ec634b84"
-  integrity sha512-dbVu2TRR8CZ254MT2CIMV5c/U4jSVJ2aLrOUECHNuSZcKZRk0dA51QA+rZeyOy7DfQQ88dOvEvkUhFfmec55Sg==
+"@oxc-parser/binding-darwin-x64@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz#56601549bad307fcee2b3e0756769e36598841f4"
+  integrity sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==
 
-"@oxc-parser/binding-freebsd-x64@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.118.0.tgz#c1a314a0a1a508e25a920700e3f44ad39d5ae814"
-  integrity sha512-TqAHom3L/3AJt72Y5IXvtffCPu9y2xnWVymlH3rmVwA+bFQAw3V8smDm3eQgAsAb4EmE17hYU8xgS/1fA0Nfvg==
+"@oxc-parser/binding-freebsd-x64@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz#68140dd5670556fca3aa094f0cb7e706854b5967"
+  integrity sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==
 
-"@oxc-parser/binding-linux-arm-gnueabihf@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.118.0.tgz#0f53dcc19311a16ada5674149e40634660dc905e"
-  integrity sha512-lxYDH+fHKX9YFXnRouaI4c4BGRT+XDsNGAtb1ZAPoDbu66+sIXUApXjc4oTM/PRmF29WE+TVhbXeOWeVv8qTSA==
+"@oxc-parser/binding-linux-arm-gnueabihf@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz#84ef8af25ffb6172b02b1747bbbef668e09235c1"
+  integrity sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==
 
-"@oxc-parser/binding-linux-arm-musleabihf@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.118.0.tgz#14129301ce34a13c67a284838088b6f8dce20a1a"
-  integrity sha512-2N54CwMbLoPqsc0VolynVqf6ug9EwNAp/g40BKLAzgReLyktJN5QlfK8DpgWmql6FQE7IavL47eibOMfHD8H8g==
+"@oxc-parser/binding-linux-arm-musleabihf@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz#ca6a2dffed23143c9bcbefd8250832c71fdfb4d7"
+  integrity sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==
 
-"@oxc-parser/binding-linux-arm64-gnu@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.118.0.tgz#9b7cc15cec668a78139166b0aa9b28c251bf7734"
-  integrity sha512-Bg5FKxz3yNAZo6WjaL4A+SDhanffw+hIS5i9kXphL2t4RXaXqFgzFflCxlTtGkETZR2+6xQwH3NsqNhTHm+NiA==
+"@oxc-parser/binding-linux-arm64-gnu@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz#ed1a4718c61d05836015c8eac7395ffe74c3f94a"
+  integrity sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==
 
-"@oxc-parser/binding-linux-arm64-musl@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.118.0.tgz#4eebc752797ff7aff518bd83bbbe9e5d6e1d2032"
-  integrity sha512-u+kIw+WIYyPs69QVcOiXYyerPjWylJLSe+AIy8v16hgaSTImWzN6FV4tiSYvPfeDGQP7svZgBuwv6P3AEPNRpg==
+"@oxc-parser/binding-linux-arm64-musl@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz#ae32a94bb666604728fa48c568ced5bb270d1819"
+  integrity sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==
 
-"@oxc-parser/binding-linux-ppc64-gnu@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.118.0.tgz#c0e3714988a353d1838b43471ddbfc35b0f8d765"
-  integrity sha512-H2yOOb9yFCNb7KznDdAkdKg/MXbZ0Txe3xRQjLUCxIncEUoCZlRofPvPeIjQNQei15NVO8IuUCPDUo0i14lRMA==
+"@oxc-parser/binding-linux-ppc64-gnu@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz#0de7511156b2b5d7d4fc3574ab3badd93a07c1ae"
+  integrity sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==
 
-"@oxc-parser/binding-linux-riscv64-gnu@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.118.0.tgz#635255ff49b6a0a80973d6e182d8f348f840c891"
-  integrity sha512-Ze1d5u/67OtB9HYIQpd/5lrFgPtLm+TyFzE+KnUpl6O1EldJXdOy4+iup5j1M+Ux9pLGJe83z1BLb6suYk1IOQ==
+"@oxc-parser/binding-linux-riscv64-gnu@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz#9a4a3b3261b6ada598b65adc4521581c45aa1003"
+  integrity sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==
 
-"@oxc-parser/binding-linux-riscv64-musl@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.118.0.tgz#f2f3e101c6a41a762448bbf5c8da44b847e1f9c7"
-  integrity sha512-41F6DXLZ3D0YzMj3kit6rpnSY+fRlnB+8vpvaccxo+HV/4D0geZWjygfQNR7SYhcyt6Jk2cNIHPYvxZFiqj+Xg==
+"@oxc-parser/binding-linux-riscv64-musl@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz#e55c1d671e41617f27535216483ccc01f1ff4a5e"
+  integrity sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==
 
-"@oxc-parser/binding-linux-s390x-gnu@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.118.0.tgz#60dfa6135a337d34e178dd529a0db6fced99028d"
-  integrity sha512-g5u0mZaJGRlJry28B7o4lcJsGKb1iAyMEToQSjNGi/t/qPrRgG0Rp6bEqFGXzYELniFeIrK0ErmopvEc3p89Mg==
+"@oxc-parser/binding-linux-s390x-gnu@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz#2e4b692103d8ee745990c7ed5fd023387e6c93d9"
+  integrity sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==
 
-"@oxc-parser/binding-linux-x64-gnu@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.118.0.tgz#981f1d2a0c8a1fcef217151f1314a042270dcd49"
-  integrity sha512-iKRgKEE1qfZNsM6YiZa5sMwDTKX+DIBmHf/pLna4iC4OwPcW0bU0fMXWOkBvt2uXeORdesa3dz3PvDMU0KqNKg==
+"@oxc-parser/binding-linux-x64-gnu@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz#2ba1d08aeaed17247dac4cb5b9a3bc83b7bd7501"
+  integrity sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==
 
-"@oxc-parser/binding-linux-x64-musl@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.118.0.tgz#e95655e0ed1c06775551e5296a5678e8421c444e"
-  integrity sha512-NpxJD33R6Uwhhhst9Diad8ojoVrObMt1PP/d+0079ukztFWiOG+Sqwmwzl6u3dm2HoenNpfPmz+pRpsuH9G3Fw==
+"@oxc-parser/binding-linux-x64-musl@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz#677889452adb283e791798faf70af0627bd493ad"
+  integrity sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==
 
-"@oxc-parser/binding-openharmony-arm64@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.118.0.tgz#d198f533716b1e14b25f60c41bc106f1a5537c4b"
-  integrity sha512-AkX9iorxLg74kXzoSrrcAX2sIzrNGUhXs55QfYWIbIt6VsaH8E4uQTg7yI5qz5+OMVGrB3oxdurWTTjyWGBO3Q==
+"@oxc-parser/binding-openharmony-arm64@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz#2928bbd0f815a7bf11a86b1bccfb0f352b92a7b3"
+  integrity sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==
 
-"@oxc-parser/binding-wasm32-wasi@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.118.0.tgz#093a0e02b8a093d669d62956a33fd7d492c67f7b"
-  integrity sha512-32jl5sokXqztJVPPNGArEq3BCh1DYCvhINHB5aFBWq1kumGC22VplMaQOg47AB1P19R1qguTe/rFckg/MN7ymA==
+"@oxc-parser/binding-wasm32-wasi@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz#37df389cce33c8664763a402853a73559b882ce2"
+  integrity sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==
   dependencies:
-    "@napi-rs/wasm-runtime" "^1.1.1"
+    "@emnapi/core" "1.10.0"
+    "@emnapi/runtime" "1.10.0"
+    "@napi-rs/wasm-runtime" "^1.1.4"
 
-"@oxc-parser/binding-win32-arm64-msvc@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.118.0.tgz#c4deeeef586ee6edd9caaff0949f4c7aae46df15"
-  integrity sha512-Csqk288t0wmwWap6uTD66S0jKbzCGF0IT+3rj6ZwKHgQIcVILMfzciVZCISSVsH8Crjz+DfRHEFhW1F6hNb09Q==
+"@oxc-parser/binding-win32-arm64-msvc@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz#b1a0913ad2545c30f498ba181c05de3898240976"
+  integrity sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==
 
-"@oxc-parser/binding-win32-ia32-msvc@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.118.0.tgz#3703fd5f2b5db199d2a8898b8c860e51c44620d2"
-  integrity sha512-qqaoLkdYfr5vBatMIfmYeE/PpV4SFO+0A4AnTJ8hTV9IhBNPpAhB46YSdfacWjVk0tRIk0OeYDUn8ohFhSYMHg==
+"@oxc-parser/binding-win32-ia32-msvc@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz#13964f4b59671f7235f4f85866ab3db6e4afd6c5"
+  integrity sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==
 
-"@oxc-parser/binding-win32-x64-msvc@0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.118.0.tgz#a28d9e015a4ea315ab00cac525492dbd467443bd"
-  integrity sha512-sOL5mOLBQT7aHdltfVhRwnDAo4fR4jnxJQU4rBQaGVmsbjK0V/358teokfIwEXNEuY2o7o9PqYnq1TkNzmcirw==
+"@oxc-parser/binding-win32-x64-msvc@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz#468339fb08809ddb856f3bc51db718790fb51f05"
+  integrity sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==
 
-"@oxc-project/types@^0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.118.0.tgz#e490bb6cc4e4e79075ff8be1196fd1ee5bf72a5a"
-  integrity sha512-yx4sGEZvH9dcS9AduoKKPWFqxJWrKtElOebwpTV9qYx387KiCoUt+iZBPmxpnnHIFc948kY5O8CJTPOmj+2y6w==
+"@oxc-project/types@^0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.132.0.tgz#d77243df4fe1a0a1e60e12ac6240fa898d2363ff"
+  integrity sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
@@ -2901,34 +2901,35 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dc-polyfill@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.10.tgz#6f2ada1a9e449587c363ca98cfb79b443cf74b70"
-  integrity sha512-9iSbB8XZ7aIrhUtWI5ulEOJ+IyUN+axquodHK+bZO4r7HfY/xwmo6I4fYYf+aiDom+WMcN/wnzCz+pKvHDDCug==
+dc-polyfill@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.11.tgz#3efa792147f3b5224b8a9274905b1e98fe82a856"
+  integrity sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==
 
 dc-polyfill@^0.1.3:
   version "0.1.9"
   resolved "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.9.tgz"
   integrity sha512-D5mJThEEk9hf+CJPwTf9JFsrWdlWp8Pccjxkhf7uUT/E/cU9Mx3ebWe2Bz2OawRmJ6WS9eaDPBkeBE4uOKq9uw==
 
-dd-trace@^5.93.0:
-  version "5.93.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.93.0.tgz#eddbc5497722fa1b4f6e00e3de10bc72c499f49a"
-  integrity sha512-5MXIZuiT3KAILIt3Cb6AGbjH9B/hinwN16ERomn1ylD8/R9rYeKjdxaVBaNnBN0suHlTrO6FqZxqHjlh4Gtm3A==
+dd-trace@^5.105.0:
+  version "5.105.0"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.105.0.tgz#2146d0628408f4977496d9145602d5f40d78ed3d"
+  integrity sha512-nu0GNq09iwf4X+nOz+32fo6f7oajj7hFAMewW2JO5L423gp2csIye4CJs0mqGxNI/1sltaKmyVAuuUhOMrJbLw==
   dependencies:
-    dc-polyfill "^0.1.10"
-    import-in-the-middle "^3.0.0"
+    dc-polyfill "^0.1.11"
+    import-in-the-middle "^3.0.1"
+    opentracing ">=0.14.7"
   optionalDependencies:
-    "@datadog/libdatadog" "0.9.2"
+    "@datadog/libdatadog" "0.9.3"
     "@datadog/native-appsec" "11.0.1"
-    "@datadog/native-iast-taint-tracking" "4.1.0"
-    "@datadog/native-metrics" "3.1.1"
-    "@datadog/openfeature-node-server" "^1.1.0"
-    "@datadog/pprof" "5.14.0"
+    "@datadog/native-iast-taint-tracking" "4.2.0"
+    "@datadog/native-metrics" "3.1.2"
+    "@datadog/openfeature-node-server" "1.2.1"
+    "@datadog/pprof" "5.14.4"
     "@datadog/wasm-js-rewriter" "5.0.1"
     "@opentelemetry/api" ">=1.0.0 <1.10.0"
     "@opentelemetry/api-logs" "<1.0.0"
-    oxc-parser "^0.118.0"
+    oxc-parser "^0.132.0"
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.7"
@@ -3392,10 +3393,10 @@ ieee754@^1.1.4:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-import-in-the-middle@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz#720c12b4c07ea58b32a54667e70a022e18cc36a3"
-  integrity sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==
+import-in-the-middle@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
+  integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==
   dependencies:
     acorn "^8.15.0"
     acorn-import-attributes "^1.9.5"
@@ -4193,6 +4194,11 @@ node-gyp-build@^4.5.0:
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz"
   integrity sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==
 
+node-gyp-build@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
@@ -4234,33 +4240,38 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-oxc-parser@^0.118.0:
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/oxc-parser/-/oxc-parser-0.118.0.tgz#296243c0e3e88a86100113824290bf5fca4e20d1"
-  integrity sha512-RWcTXXw9rsdlGxPwaL2hVKDtgudMBAUlwqPNl1WhgWQNlp/RZ/XeFHuG8HolZM2dMjLJeD4b2Ywo7/a988X4MQ==
+opentracing@>=0.14.7:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
+  integrity sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==
+
+oxc-parser@^0.132.0:
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/oxc-parser/-/oxc-parser-0.132.0.tgz#4f0ffad5ccfd0235a8ba79f7e6fc988be6f45476"
+  integrity sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==
   dependencies:
-    "@oxc-project/types" "^0.118.0"
+    "@oxc-project/types" "^0.132.0"
   optionalDependencies:
-    "@oxc-parser/binding-android-arm-eabi" "0.118.0"
-    "@oxc-parser/binding-android-arm64" "0.118.0"
-    "@oxc-parser/binding-darwin-arm64" "0.118.0"
-    "@oxc-parser/binding-darwin-x64" "0.118.0"
-    "@oxc-parser/binding-freebsd-x64" "0.118.0"
-    "@oxc-parser/binding-linux-arm-gnueabihf" "0.118.0"
-    "@oxc-parser/binding-linux-arm-musleabihf" "0.118.0"
-    "@oxc-parser/binding-linux-arm64-gnu" "0.118.0"
-    "@oxc-parser/binding-linux-arm64-musl" "0.118.0"
-    "@oxc-parser/binding-linux-ppc64-gnu" "0.118.0"
-    "@oxc-parser/binding-linux-riscv64-gnu" "0.118.0"
-    "@oxc-parser/binding-linux-riscv64-musl" "0.118.0"
-    "@oxc-parser/binding-linux-s390x-gnu" "0.118.0"
-    "@oxc-parser/binding-linux-x64-gnu" "0.118.0"
-    "@oxc-parser/binding-linux-x64-musl" "0.118.0"
-    "@oxc-parser/binding-openharmony-arm64" "0.118.0"
-    "@oxc-parser/binding-wasm32-wasi" "0.118.0"
-    "@oxc-parser/binding-win32-arm64-msvc" "0.118.0"
-    "@oxc-parser/binding-win32-ia32-msvc" "0.118.0"
-    "@oxc-parser/binding-win32-x64-msvc" "0.118.0"
+    "@oxc-parser/binding-android-arm-eabi" "0.132.0"
+    "@oxc-parser/binding-android-arm64" "0.132.0"
+    "@oxc-parser/binding-darwin-arm64" "0.132.0"
+    "@oxc-parser/binding-darwin-x64" "0.132.0"
+    "@oxc-parser/binding-freebsd-x64" "0.132.0"
+    "@oxc-parser/binding-linux-arm-gnueabihf" "0.132.0"
+    "@oxc-parser/binding-linux-arm-musleabihf" "0.132.0"
+    "@oxc-parser/binding-linux-arm64-gnu" "0.132.0"
+    "@oxc-parser/binding-linux-arm64-musl" "0.132.0"
+    "@oxc-parser/binding-linux-ppc64-gnu" "0.132.0"
+    "@oxc-parser/binding-linux-riscv64-gnu" "0.132.0"
+    "@oxc-parser/binding-linux-riscv64-musl" "0.132.0"
+    "@oxc-parser/binding-linux-s390x-gnu" "0.132.0"
+    "@oxc-parser/binding-linux-x64-gnu" "0.132.0"
+    "@oxc-parser/binding-linux-x64-musl" "0.132.0"
+    "@oxc-parser/binding-openharmony-arm64" "0.132.0"
+    "@oxc-parser/binding-wasm32-wasi" "0.132.0"
+    "@oxc-parser/binding-win32-arm64-msvc" "0.132.0"
+    "@oxc-parser/binding-win32-ia32-msvc" "0.132.0"
+    "@oxc-parser/binding-win32-x64-msvc" "0.132.0"
 
 p-limit@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
The datadog-lambda-js/package.json is not included in our layers, because the layer build only copies `dist` there in Dockerfile (line 15).



What changed in dd-trace@5.105.0 is the hook wrapper behavior:
```
moduleVersion ||= getVersion(moduleBaseDir)
```
getVersion() calls `requirePackageJson(moduleBaseDir, module)`. For this layer, moduleBaseDir is effectively:
/opt/nodejs/node_modules/datadog-lambda-js

1. MetricsListener.createProcessor() calls require("./api") in src/metrics/listener.ts (line 146).
2. dd-trace’s require hook sees this as an internal file under the instrumented package datadog-lambda-js. Before letting the lambda hook decide whether to patch it, dd-trace@5.105.0 tries to read datadog-lambda-js/package.json, which fails.
3. The hook returns undefined. Therefore require("./api") becomes undefined, and destructuring { APIClient } throws.

dd-trace@5.93.0 did not care in this path. Its hook wrapper did not try to read the target package’s package.json before returning module exports. So for datadog-lambda-js/metrics/api.js it just passed the real module exports through






