### PR TITLE
fix: Node profiler crash on init by pinning @datadog/pprof to dd-trace 5.105's required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "devDependencies": {
     "@aws-sdk/client-kms": "^3.366.0",
     "@aws-sdk/client-secrets-manager": "^3.721.0",
-    "@datadog/pprof": "*",
-    "@opentelemetry/api": "*",
-    "@opentelemetry/api-logs": "*",
+    "@datadog/pprof": "5.14.4",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
+    "@opentelemetry/api-logs": "<1.0.0",
     "@types/aws-lambda": "^8.10.136",
     "@types/aws-sdk": "^2.7.0",
     "@types/jest": "^27.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,17 +1185,6 @@
   dependencies:
     "@datadog/flagging-core" "^1.2.1"
 
-"@datadog/pprof@*":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.13.2.tgz#9361809e712417e04c21e7f7ea239bfb3513c358"
-  integrity sha512-Th8u7pvoguTfbUx/mlZLHD9TxFCHO+wRAvlEaYFAYAmMvbPLww4YowvTy1UMvpi8LbUbwil3Fo8rKCrilvXHhQ==
-  dependencies:
-    delay "^5.0.0"
-    node-gyp-build "<4.0"
-    p-limit "^3.1.0"
-    pprof-format "^2.2.1"
-    source-map "^0.7.4"
-
 "@datadog/pprof@5.14.4":
   version "5.14.4"
   resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.14.4.tgz#4a242b6e9c78f66aff836e926b28733749cfa83b"
@@ -1461,14 +1450,14 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
 
-"@opentelemetry/api-logs@*", "@opentelemetry/api-logs@<1.0.0":
+"@opentelemetry/api-logs@<1.0.0":
   version "0.208.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz#56d3891010a1fa1cf600ba8899ed61b43ace511c"
   integrity sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@*", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@^1.3.0":
+"@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@^1.3.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
@@ -2962,11 +2951,6 @@ define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
-delay@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz"
-  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
@@ -4184,7 +4168,7 @@ node-addon-api@^6.1.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz"
   integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
-node-gyp-build@<4.0, node-gyp-build@^3.9.0:
+node-gyp-build@^3.9.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz"
   integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
@@ -4279,13 +4263,6 @@ p-limit@^2.2.0:
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
-
-p-limit@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -5031,8 +5008,3 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
## Summary

  Pins three layer-bundled dependencies in package.json to the exact versions/ranges that dd-trace@5.105.0 declares in its optionalDependencies. The important one is @datadog/pprof, which was resolving to a stale
  5.13.2 and breaking profiler startup on Node.

## Background / root cause

  The serverless Node layer bundles whatever scripts/move_ddtrace_dependency.js promotes from devDependencies into dependencies at build time — namely dd-trace, @datadog/pprof, @opentelemetry/api, and @opentelemetry/api-logs. These ship at the top level of the layer's node_modules, so they shadow dd-trace's own nested copies.
  @datadog/pprof was declared as "*", which yarn.lock had pinned to 5.13.2. Meanwhile dd-trace@5.105.0 pins @datadog/pprof@5.14.4 in its optionalDependencies. The two versions have an incompatible SourceMapper API:

- 5.13.2 — only a static SourceMapper.create(searchDirs) factory.
- 5.14.4 — adds an async loadDirectory(searchDir) instance method.

  dd-trace@5.105's profiling/profiler.js calls new `SourceMapper(...).loadDirectory(process.cwd())`. Against the hoisted 5.13.2, that throws at profiler startup:
```
  Error: Error starting profiler. (https://dtdg.co/nodejs-profiler-troubleshooting)
    at Tracer._startProfiler (.../dd-trace/src/proxy.js:258:11)
  TypeError: mapper.loadDirectory is not a function
    at ServerlessProfiler.start (.../dd-trace/src/profiling/profiler.js:173:14)
```
  The profiler never starts, so the datadog.profiling.agent metric is never emitted. This was caught by the serverless-e2e-tests test_profiling_usage failing for all Node versions after the dd-trace 5.93→5.105
  bump.

## Changes (package.json devDependencies)

  Each value now matches dd-trace@5.105.0's optionalDependencies exactly:

| Dependency | Before | After | dd-trace 5.105 requires| 
|---|---|---|---|
|@datadog/pprof  |"*" (→ 5.13.2) |"5.14.4"  |5.14.4 |
|@opentelemetry/api  |"*"    |">=1.0.0 <1.10.0"  | >=1.0.0 <1.10.0|
|@opentelemetry/api-logs |"*"  |"<1.0.0"|<1.0.0  |

  dd-trace itself was already ^5.105.0 and is unchanged.

  @opentelemetry/api / api-logs were not actually broken (their "*" already de-duped with dd-trace's ranges to 1.9.0 / 0.208.0), but they're pinned to the same ranges dd-trace declares so the layer can't drift past
  dd-trace's supported range in a future install (e.g. pulling otel-api ≥1.10).

  yarn.lock is regenerated: the duplicate @datadog/pprof@* (5.13.2) specifier collapses into the single @datadog/pprof@5.14.4 entry.

## Verification
  - e2e tests passed!
  - Top-level @datadog/pprof now resolves to 5.14.4, and it is the only copy of pprof in node_modules (no stale 5.13.2 remaining).
  - The loadDirectory instance method is present in the resolved pprof.
  - After rebuilding the layer, move_ddtrace_dependency.js promotes @datadog/pprof@5.14.4, so /opt/nodejs/node_modules/@datadog/pprof ships with loadDirectory and the profiler starts cleanly.
