### PR TITLE
ci: drop redundant NodeGYP install step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Install NodeGYP 
-        if: matrix.node-version == '20.19' || matrix.node-version == '22.11' || matrix.node-version == '24.11'
-        run: yarn global add node-gyp
-
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
## What

Removes the `Install NodeGYP` step from the unit-test matrix in `.github/workflows/build.yml`.

```diff
-      - name: Install NodeGYP
-        if: matrix.node-version == '20.19' || matrix.node-version == '22.11' || matrix.node-version == '24.11'
-        run: yarn global add node-gyp
-
       - name: Install dependencies
         run: yarn install
```

## Why

### Symptom

Every PR and `main` build was failing on `Install NodeGYP` with:

```
error proc-log@7.0.0: The engine "node" is incompatible with this module.
Expected version "^22.22.2 || ^24.15.0 || >=26.0.0". Got "20.19.6"
error Found incompatible module.
##[error]Process completed with exit code 1.
```

### Root cause

`node-gyp@13.0.0` bumped its transitive dependency on `proc-log` from `^6` to `^7`. `proc-log@7.0.0` tightened its `engines.node` declaration from `^20.17.0 || >=22.9.0` to `^22.22.2 || ^24.15.0 || >=26.0.0`. None of the Node versions in our CI matrix satisfy the new constraint:

| Matrix Node | Satisfies `proc-log@7` engines? |
|---|---|
| 18.12 | no (also excluded by the conditional) |
| 20.19 | no |
| 22.11 | no (needs 22.22.2+) |
| 24.11 | no (needs 24.15.0+) |

### Why drop rather than pin

`node-gyp` is a fallback tool used to compile native C/C++ addons from source at install time when no prebuilt binary is available. Two reasons this global install step is no longer earning its keep:

1. The modern `npm` bundled with Node 20+ already ships its own `node-gyp` and uses it automatically when a native build is needed. Installing one globally is redundant.
2. The `18.12` matrix entry has *never* run this step (the conditional excludes it) and `yarn install` succeeds there. That's direct evidence the global install isn't required for the current dep tree.

If a future native dependency genuinely needs a specific `node-gyp` on a specific Node version, we can reintroduce a scoped, pinned step then.

### Alternatives considered

- **Pin to `node-gyp@12`** (which uses `proc-log@^6`): works but treats a symptom rather than the underlying redundancy.
- **`--ignore-engines` flag**: silently masks engine mismatches in the future.

## Scope

CI-only change. No runtime/source code touched.

## Test plan

- [ ] All four unit-test matrix jobs (18.12, 20.19, 22.11, 24.11) go green on this PR (especially `yarn install` and `yarn build`, which is where any missing-native-binary fallout would surface).
- [ ] `lint` and `build (...)` jobs are unaffected.