### PR TITLE
chore: strip dd-trace Test Optimization validation runbook from layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,11 @@ RUN rm -rf /nodejs/node_modules/@datadog/native-appsec/prebuilds/win32-x64
 RUN rm -rf /nodejs/node_modules/@datadog/native-appsec/prebuilds/linuxmusl-arm64
 RUN rm -rf /nodejs/node_modules/@datadog/native-appsec/prebuilds/linuxmusl-x64
 
+# Remove the Test Optimization validation runbook from dd-trace. It is agent-guided
+# debugging tooling for CI environments and is never loaded in a lambda environment.
+RUN rm -rf /nodejs/node_modules/dd-trace/ci
+RUN rm -rf /nodejs/node_modules/dd-trace/packages/dd-trace/src/ci-visibility/exporters/ci-validation
+
 # Remove heavy files from @opentelemetry/api which aren't used in a lambda environment.
 # TODO: Create a completely separate Datadog scoped package for OpenTelemetry instead.
 RUN rm -rf /nodejs/node_modules/@opentelemetry/api/build/esm


### PR DESCRIPTION
## What

Adds two `rm -rf` lines to the layer `Dockerfile` to remove dd-trace's Test Optimization validation runbook from the published Lambda layer:

- `/nodejs/node_modules/dd-trace/ci`
- `/nodejs/node_modules/dd-trace/packages/dd-trace/src/ci-visibility/exporters/ci-validation`

## Why

[DataDog/dd-trace-js#9323](https://github.com/DataDog/dd-trace-js/pull/9323) ships an agent-guided Test Optimization debug runbook (`ci/runbook.md` + scripts under `ci/test-optimization-validation/`, ~150KB / ~17k lines) inside the npm package, and `ci/**/*` is in dd-trace's `files` list, so it lands in our layer on the next dd-trace bump.

The code is fully gated behind private env vars (`_DD_TEST_OPTIMIZATION_VALIDATION_MODE` etc.) and is never loaded in a Lambda environment — it's dead weight for us. Since we already strip unused files to keep the layer small, strip this too. Removing the whole `dd-trace/ci` directory also reclaims the pre-existing `ci/init.js` CI-visibility entrypoint, which Lambda never loads either.

`packages/dd-trace/src/ci-visibility/test-optimization-http-cache.js` is intentionally kept: `ci-visibility-exporter.js` now requires it at module load, and it's only ~300 lines.