### PR TITLE
Release v12.142.0

### DIFF
--- a/.claude/skills/release-lambda-layer/SKILL.md
+++ b/.claude/skills/release-lambda-layer/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: release-lambda-layer
+description: Walks through releasing a new datadog-lambda-js Lambda layer version — the automated Commercial release (version bump, tag, GitLab sign/publish jobs, npm publish, GitHub release) and the manual GovCloud layer publish. Pauses for explicit confirmation before every irreversible or externally-visible step (tag push, GitLab manual jobs, npm publish, GitHub release, GovCloud deploy). Triggers on "release a new layer version", "cut a new datadog-lambda-js release", "publish the lambda layer", or similar. Source of truth: https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2724037230/Lambda+Layer+Node.js#Commercial
+user-invocable: true
+agent-invocable: true
+---
+
+# Release a new datadog-lambda-js Lambda layer
+
+This mirrors the "Release" section of the SLS Confluence page "Lambda Layer
+Node.js" (Commercial + GovCloud). It assumes a Release Candidate has
+already been validated (self-monitoring + e2e tests passed) before this
+process starts.
+
+This process pushes git tags, triggers production-publishing GitLab jobs,
+publishes to the public npm registry, and creates a public GitHub release.
+**Treat every step in the "Guardrails" section as a hard stop** — confirm
+with the user before running it, even if they've approved a similar step
+earlier in the same run.
+
+## Before starting
+
+- Announce the start of the release in a **#apm-serverless** Slack thread.
+  Use this same thread for every update below. Ask the user to post, don't
+  post on their behalf unless they've explicitly asked you to send Slack
+  messages for them.
+- Confirm a Release Candidate deploy already passed self-monitoring and
+  e2e tests for this change. Do not start Phase 1 without it.
+
+## Phase 1 — Commercial release
+
+Reference: https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3375925277
+
+1. Create a branch for the version bump.
+2. Run `yarn upgrade dd-trace` (or `yarn upgrade dd-trace@^a.b.c` for a
+   specific version) to pick up the latest tracer.
+3. If dd-trace changed, refresh integration test snapshots:
+   `BUILD_LAYERS=true UPDATE_SNAPSHOTS=true DD_API_KEY=<key from 1Password> aws-vault exec sso-serverless-sandbox-account-admin -- ./scripts/run_integration_tests.sh`
+4. Bump `package.json` version to `X.Y.0`:
+   - Minor version bumps on every release, and **must match the layer
+     version**.
+   - Bump major too for breaking changes.
+5. Commit as `vX.Y.0`, open a PR, get approval.
+6. **Before merging**, confirm a Release Candidate deploy already passed
+   for this change (per "Before starting" above).
+7. Merge the PR. **Tell the user not to merge any other PR until this
+   release finishes** — a concurrent merge can tag the wrong commit.
+8. `git checkout main && git pull`
+9. `git tag vX.Y.0`
+10. `git push --tags origin main` — **guardrail: confirm with the user
+    before running this.** It kicks off the production build in GitLab and
+    can't be cleanly undone.
+11. In [GitLab tags](https://gitlab.ddbuild.io/DataDog/datadog-lambda-js/-/tags),
+    open the pipeline for the new tag.
+12. **Guardrail: confirm before triggering**, then run the `sign-layer
+    (nodeXX)` manual job for every supported runtime. This deploys the
+    layer to every commercial region.
+13. **Guardrail: confirm before triggering**, then run the
+    `publish-npm-package` manual job. Afterward, verify publicly:
+    ```
+    mkdir new-dir && cd new-dir && npm init -y
+    npm install datadog-lambda-js@<new version>
+    ```
+14. **Guardrail: confirm before creating**, then draft a GitHub release on
+    the [releases page](https://github.com/DataDog/datadog-lambda-js/releases):
+    - Select the new tag and the previous tag, generate release notes.
+    - Paste in layer ARNs for every runtime and region pattern, e.g.:
+      ```
+      arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Node18-x:117
+      arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Node20-x:117
+      arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Node22-x:117
+
+      arn:aws-us-gov:lambda:us-gov-<AWS_REGION>:002406178527:layer:Datadog-Node18-x:117
+      arn:aws-us-gov:lambda:us-gov-<AWS_REGION>:002406178527:layer:Datadog-Node20-x:117
+      arn:aws-us-gov:lambda:us-gov-<AWS_REGION>:002406178527:layer:Datadog-Node22-x:117
+      ```
+      (substitute the actual layer version number for `117`)
+    - Attach the layer zip files.
+15. Post the finished release + release notes link to the Slack thread.
+
+## Phase 2 — GovCloud (manual)
+
+No automated pipeline exists for this — compliance requirements mean it has
+to stay manual.
+
+1. Confirm AWS SSO is set up for both Commercial and GovCloud (see
+   [cloud-inventory setup](https://github.com/DataDog/cloud-inventory/tree/master/organizations/aws#aws-cli-config-setup--update)).
+2. From the Phase 1 pipeline's Sign layer jobs, download each job's
+   artifacts and place the layer bundle zips in the local `.layers` folder.
+3. **Guardrail: confirm before running**, then for each GovCloud
+   environment:
+   ```
+   VERSION=<LAYER_VERSION> ENVIRONMENT=us1-fed ./scripts/publish_govcloud_layers.sh <path-to-layer-bundle.zip>
+   VERSION=<LAYER_VERSION> ENVIRONMENT=us2-fed ./scripts/publish_govcloud_layers.sh <path-to-layer-bundle.zip>
+   ```
+   `VERSION` is the integer layer version (e.g. `116`), not the npm semver.
+   When prompted for auth, the user must open the link in their GovCloud
+   browser profile — don't attempt to open or approve it yourself.
+4. **Guardrail: confirm before editing**, then update
+   [`latest-lambda-layer-version.html`](https://github.com/DataDog/documentation/blob/master/layouts/shortcodes/latest-lambda-layer-version.html)
+   in the `documentation` repo to the new version, via a PR.
+
+## Guardrails (always confirm before)
+
+- `git push --tags origin main`
+- Triggering any GitLab manual job that publishes/signs a layer or
+  publishes the npm package
+- Creating the GitHub release
+- Running `publish_govcloud_layers.sh`
+- Opening a PR against the `documentation` repo
+- Merging any release-version-bump PR
+
+## Failure modes
+
+- If integration test snapshots don't update correctly, check the
+  installed `serverless` framework is v3, not v4:
+  `npm install -g serverless@3.39.0`.
+- If a teammate merges a PR to `main` between step 7 and step 9 of Phase 1,
+  stop and confirm with the user which commit should actually be tagged.

--- a/.claude/skills/release-lambda-layer/SKILL.md
+++ b/.claude/skills/release-lambda-layer/SKILL.md
@@ -55,8 +55,15 @@ Reference: https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3375925277
 12. **Guardrail: confirm before triggering**, then run the `sign-layer
     (nodeXX)` manual job for every supported runtime. This deploys the
     layer to every commercial region.
+    - Claude does not have GitLab UI/API access by default, so this is
+      normally an instruction the user runs themselves — walk them through
+      clicking the job in the GitLab pipeline and wait for them to confirm
+      it finished before moving on. Only trigger it directly if the user
+      has explicitly set up GitLab API credentials for Claude to use, and
+      still confirm before every single trigger, per the guardrail above.
 13. **Guardrail: confirm before triggering**, then run the
-    `publish-npm-package` manual job. Afterward, verify publicly:
+    `publish-npm-package` manual job (same access caveat as step 12).
+    Afterward, verify publicly:
     ```
     mkdir new-dir && cd new-dir && npm init -y
     npm install datadog-lambda-js@<new version>
@@ -64,6 +71,9 @@ Reference: https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3375925277
 14. **Guardrail: confirm before creating**, then draft a GitHub release on
     the [releases page](https://github.com/DataDog/datadog-lambda-js/releases):
     - Select the new tag and the previous tag, generate release notes.
+    - Call out which `dd-trace` version is packaged in this release (from
+      step 2 of Phase 1) — this is important for users debugging tracer
+      behavior against a specific layer version.
     - Paste in layer ARNs for every runtime and region pattern, e.g.:
       ```
       arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Node18-x:117
@@ -85,8 +95,11 @@ to stay manual.
 
 1. Confirm AWS SSO is set up for both Commercial and GovCloud (see
    [cloud-inventory setup](https://github.com/DataDog/cloud-inventory/tree/master/organizations/aws#aws-cli-config-setup--update)).
-2. From the Phase 1 pipeline's Sign layer jobs, download each job's
-   artifacts and place the layer bundle zips in the local `.layers` folder.
+2. Check the Phase 1 pipeline for a single job that bundles all runtimes'
+   signed layers together (e.g. a "signed layer bundle" artifact) — if one
+   exists, download that instead of going job-by-job. Otherwise, fall back
+   to downloading each individual `sign-layer (nodeXX)` job's artifacts.
+   Place the resulting layer bundle zips in the local `.layers` folder.
 3. **Guardrail: confirm before running**, then for each GovCloud
    environment:
    ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "12.141.0",
+  "version": "12.142.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,7 +1193,7 @@
 
 "@datadog/flagging-core@1.2.1":
   version "1.2.1"
-  resolved "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-1.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/@datadog/flagging-core/-/flagging-core-1.2.1.tgz#1bb2d1ecfd749033ed2570eccc8fb0697b8adfac"
   integrity sha512-qeDkki9fFlqyoZBrn7tneT6pZ04EKKvf3xxisYw1a74zbJihvQui/ARUsjXCurRpzpFqGGTJw/oz+HnXaKhcdw==
   dependencies:
     spark-md5 "^3.0.2"
@@ -1212,14 +1212,14 @@
 
 "@datadog/native-iast-taint-tracking@4.2.0":
   version "4.2.0"
-  resolved "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.2.0.tgz#ca05a1510af130e14fad7721b539dcf151ee235f"
   integrity sha512-NpZABJQoNMzF6cU521RT4GQ8/FbfFRoDepOLTcLYKyw0DY2WmSpg3iG+PoQNK4O3jPSXC++K3rg59GiQgA3Mog==
   dependencies:
     node-gyp-build "^3.9.0"
 
 "@datadog/native-metrics@3.1.2":
   version "3.1.2"
-  resolved "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.1.2.tgz#9dc269bdbc6f5b5c9a30dc6d99bab44d17dd5a37"
   integrity sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==
   dependencies:
     node-addon-api "^6.1.0"
@@ -1241,18 +1241,18 @@
     pprof-format "^2.2.1"
     source-map "^0.7.4"
 
-"@datadog/pprof@5.15.1":
-  version "5.15.1"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.15.1.tgz#934180721351571ad75b1bce7bde406e6b519aaf"
-  integrity sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==
+"@datadog/pprof@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.17.0.tgz#1a40cb77243cbfccd1684c70992512f533addb67"
+  integrity sha512-BuedZ4vHzmQkitMMdIhVLQ+nPpHl7WRwcuumJeXt0ylhwGGwt7Kf+4CoS1tDB0FljJXi4izweFfFFTirrijP5w==
   dependencies:
     node-gyp-build "^4.8.4"
     pprof-format "^2.2.1"
-    source-map "^0.7.4"
+    source-map "^0.8.0"
 
 "@datadog/wasm-js-rewriter@5.0.1":
   version "5.0.1"
-  resolved "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz#f227d2e3eb0f83b8a37f190a9ff8fdbde5955782"
   integrity sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==
   dependencies:
     js-yaml "^4.1.0"
@@ -1529,9 +1529,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@napi-rs/wasm-runtime@^1.1.4":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
-  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz#d7aa398845e3ab1c9c8f81ea50f527ed37d16715"
+  integrity sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==
   dependencies:
     "@tybys/wasm-util" "^0.10.3"
 
@@ -1559,7 +1559,7 @@
 
 "@oxc-parser/binding-darwin-arm64@0.132.0":
   version "0.132.0"
-  resolved "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz"
+  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz#033a8f2789c3d09509ddd1a219dcbf2fd516125f"
   integrity sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==
 
 "@oxc-parser/binding-darwin-x64@0.132.0":
@@ -1653,7 +1653,7 @@
 
 "@oxc-project/types@^0.132.0":
   version "0.132.0"
-  resolved "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.132.0.tgz#d77243df4fe1a0a1e60e12ac6240fa898d2363ff"
   integrity sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==
 
 "@sinonjs/commons@^1.7.0":
@@ -2547,7 +2547,7 @@ cjs-module-lexer@^1.0.0:
 
 cjs-module-lexer@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
   integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
 cliui@^7.0.2:
@@ -2661,12 +2661,12 @@ dc-polyfill@^0.1.11:
   integrity sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==
 
 dd-trace@^5.113.0:
-  version "5.115.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.115.0.tgz#9163c107cbb73b5d3584c733ebec7d71b212b8b9"
-  integrity sha512-bZpHDDUmhSo4nQRr1j8VFdLOYK+r7XquK3wS6TqYFvkdH0hhDgmOUmypQG7i1/lEcRFQBY+Z76Tyio8/LAl0sw==
+  version "5.118.0"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.118.0.tgz#a3fbbcc21e9739d96a386dc5e4fbbca0647f7392"
+  integrity sha512-1VNK9st2x9He3na50/L9TrSFDhGavbAy1DEHdRhc8FBipAdVZTZPTSkQdar1z0vi0ZpmW3fMWfzAeGj328d77w==
   dependencies:
     dc-polyfill "^0.1.11"
-    import-in-the-middle "^3.3.1"
+    import-in-the-middle "^3.3.2"
     opentracing ">=0.14.7"
   optionalDependencies:
     "@datadog/libdatadog" "0.9.4"
@@ -2674,7 +2674,7 @@ dd-trace@^5.113.0:
     "@datadog/native-iast-taint-tracking" "4.2.0"
     "@datadog/native-metrics" "3.1.2"
     "@datadog/openfeature-node-server" "2.0.0"
-    "@datadog/pprof" "5.15.1"
+    "@datadog/pprof" "5.17.0"
     "@datadog/wasm-js-rewriter" "5.0.1"
     "@opentelemetry/api" ">=1.0.0 <1.10.0"
     "@opentelemetry/api-logs" "<1.0.0"
@@ -3114,10 +3114,10 @@ ieee754@^1.1.4:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-import-in-the-middle@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz#4fe3b46cc1b4573b00bc69343e5f9bbf25679743"
-  integrity sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==
+import-in-the-middle@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz#af7dacd4f3c25826abfc8314ebc71b6dcf47e238"
+  integrity sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==
   dependencies:
     cjs-module-lexer "^2.2.0"
     es-module-lexer "^2.2.0"
@@ -3904,7 +3904,7 @@ node-gyp-build@^3.9.0:
 
 node-gyp-build@^4.5.0, node-gyp-build@^4.8.4:
   version "4.8.4"
-  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-int64@^0.4.0:
@@ -3950,12 +3950,12 @@ onetime@^5.1.2:
 
 opentracing@>=0.14.7:
   version "0.14.7"
-  resolved "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
   integrity sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==
 
 oxc-parser@^0.132.0:
   version "0.132.0"
-  resolved "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz"
+  resolved "https://registry.yarnpkg.com/oxc-parser/-/oxc-parser-0.132.0.tgz#4f0ffad5ccfd0235a8ba79f7e6fc988be6f45476"
   integrity sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==
   dependencies:
     "@oxc-project/types" "^0.132.0"
@@ -4063,9 +4063,9 @@ possible-typed-array-names@^1.0.0:
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
 pprof-format@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/pprof-format/-/pprof-format-2.2.2.tgz#cdee9a4c596f859876a7f8b122746f6817652c97"
-  integrity sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pprof-format/-/pprof-format-2.3.0.tgz#d2e6843e522c6eae6231224064fdb5567db5c2f1"
+  integrity sha512-ovChRLoV4H3k0zKWq0AXewtnuPGskzBLjBPmF2N0DZu+H65PYuo51+6e/1GTb8Olm7oC0xvhhLdqPL4/XhCl4A==
 
 prettier@^2.3.0:
   version "2.8.8"
@@ -4286,9 +4286,14 @@ source-map@^0.7.4:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
 
+source-map@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0.tgz#72b9006383bd9fc70d52e435c91c2d73249c60a4"
+  integrity sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==
+
 spark-md5@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
 sprintf-js@~1.0.2:


### PR DESCRIPTION
## Summary
- Bump layer/package version to 12.142.0
- Adds claude skill for releasing the layer

Includes since last release (v12.141.0):
- #802 Add ap-east-2 and ap-southeast-6 to supported regions
- #790 feat: add support for extracting DSM context in event bridge

## Test plan
- [x] Integration test snapshots refreshed against sandbox with updated dd-trace
- [ ] Release Candidate deploy validated (self-monitoring + e2e)