### PR TITLE
Pin serverless version

### DIFF
--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -9,9 +9,9 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 
-# Install Yarn and Typescript globally
-RUN npm install --global yarn typescript
-RUN yarn global add serverless@^3 --prefix /usr/local
+# Install Yarn, TypeScript, and Serverless globally.
+# Pin Serverless 3.39.0: newer 3.x releases require Node >= 20 via @aws-sdk/client-lambda.
+RUN npm install --global yarn typescript serverless@3.39.0
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Newer versions of serverless plugin require node > 20 and we run on 18. Results in ci image job erroring with
`------
Dockerfile:14
--------------------
  12 |     # Install Yarn and Typescript globally
  13 |     RUN npm install --global yarn typescript
  14 | >>> RUN yarn global add serverless@^3 --prefix /usr/local
  15 |     
  16 |     # Install AWS CLI
--------------------
error: failed to solve: process "/bin/bash -o xtrace -o errexit -o nounset -o pipefail -c yarn global add serverless@^3 --prefix /usr/local" did not complete successfully: exit code: 1`

Gitlab: https://gitlab.ddbuild.io/DataDog/datadog-lambda-js/-/jobs/1962873504

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
