### PR TITLE
test: cover callback handlers, fetch, metrics-only, payload capture in local integration harness

### DIFF
--- a/integration_tests/container/cjs/callback.js
+++ b/integration_tests/container/cjs/callback.js
@@ -1,0 +1,16 @@
+// Callback-style handler — (event, context, callback) instead of async —
+// manually wrapped with datadog(). The migration spike broke exactly this
+// seam: the new host's tracePromise wrapper replaced promisifiedHandler's
+// call site, so callback handlers returned null to API Gateway. handler.spec
+// pins the unit behavior; this case pins the same path end to end through
+// the RIE invoke. The setTimeout makes the completion genuinely asynchronous
+// so the wrapper cannot mistake it for a sync return.
+const { datadog } = require("datadog-lambda-js");
+
+function handle(event, context, callback) {
+  setTimeout(() => {
+    callback(null, { message: "hello, dog!" });
+  }, 10);
+}
+
+module.exports.handle = datadog(handle);

--- a/integration_tests/container/cjs/fetch-requests.js
+++ b/integration_tests/container/cjs/fetch-requests.js
@@ -1,0 +1,35 @@
+// fetch variant of http-requests.js. On Node 18+ the global fetch is
+// undici, which dd-trace instruments through its undici plugin — a different
+// injection path than the http/https plugin that patches axios in
+// http-requests.js. Both paths must keep injecting the x-datadog-* trace
+// context; this case pins the fetch one.
+//
+// Like http-requests.js this entry point is UNWRAPPED and runs through the
+// npm redirect entry (dist/handler.handler) in the cjs-fetch-requests case,
+// so dd-trace initializes before the user handler loads and the tracer's
+// undici plugin does the injection. The mock echoes the request headers and
+// this handler logs them, so the golden shows the injected downstream trace
+// context (x-datadog-trace-id / x-datadog-parent-id, normalized to XXXX).
+const { sendDistributionMetric } = require("datadog-lambda-js");
+
+const urls = (process.env.MOCK_HTTP_URLS ||
+  "https://ip-ranges.datadoghq.com,https://ip-ranges.datadoghq.eu"
+).split(",");
+
+async function handle(event, context) {
+  const responsePayload = { message: "hello, dog!" };
+
+  sendDistributionMetric("serverless.integration_test.execution", 1, "function:fetch-request");
+
+  for (let index = 0; index < urls.length; index++) {
+    const response = await fetch(urls[index]);
+    const body = await response.json();
+    console.log(`mock-http saw headers for ${urls[index]}: ${JSON.stringify(body.headers)}`);
+  }
+
+  console.log(`Snapshot test fetch requests successfully made to URLs: ${urls}`);
+
+  return responsePayload;
+}
+
+module.exports.handle = handle;

--- a/integration_tests_local/README.md
+++ b/integration_tests_local/README.md
@@ -61,8 +61,12 @@ The case names are:
 | `manual-status-500` | manual wrap with userland `dd-trace` init returning a 500 API Gateway response (`DD_TRACE_ENABLED=true`); error span tag + enhanced error metrics |
 | `manual-send-metrics` | manual wrap calling `sendDistributionMetric` inside and outside the handler; per-event return values |
 | `manual-process-input` | manual wrap with userland `dd-trace` init reading the active span; per-event return values |
+| `manual-callback` | manual wrap of a callback-style `(event, context, callback)` handler; pins the `promisifiedHandler` seam end to end (the migration spike broke exactly this) |
+| `manual-metrics-only` | `DD_TRACE_ENABLED=false` (metrics-only customers): enhanced + custom metrics still flush, no `aws.lambda` span, no trace JSON, no `dd.trace_id` log correlation |
+| `cjs-capture-payload` | `DD_CAPTURE_LAMBDA_PAYLOAD=true` in redirect mode; span meta gains `function.request` / `function.response` with the captured payloads |
 | `cjs-http-requests` | downstream HTTP calls against a hermetic mock server in redirect mode; asserts injected `x-datadog-*`/`traceparent` headers and log injection via dd-trace's http plugin |
 | `manual-http-requests` | same handler, manual wrap without userland dd-trace init; exercises the library's own `patchHttp` fallback (request wrapping + per-request logging + exact header set via mock echo) |
+| `cjs-fetch-requests` | fetch variant of `cjs-http-requests`: the global fetch (undici) is instrumented by a different dd-trace plugin than http/https; mock echo pins the injected headers on that path |
 | `cjs-custom-extractor` | `DD_TRACE_EXTRACTOR=extractor.extract`; asserts `_dd.parent_source: event` on the inferred span |
 | `cjs-proactive-init` | eager-init managed-instances RIE path with a 15 s init→invoke gap; asserts proactive-initialization markers on the raw logs |
 
@@ -281,3 +285,16 @@ endpoints). Do not diff one suite's output against the other's snapshots.
 - The layer fixture installs into a plain `/opt/nodejs/node_modules`
   directory rather than a real published layer zip, so layer-version
   metadata (e.g. an exact layer ARN in tags) cannot be reproduced locally.
+
+Deliberately not covered locally (each has an assigned owner — do not re-add
+here without closing that owner first):
+
+- response streaming and `time_to_first_byte` — RIE cannot stream
+  invocations; owned by the `serverless-e2e-tests` lambda-features suite.
+- direct-API and KMS/Secrets Manager metric key paths — need real AWS;
+  unit specs plus an L3 spot-check.
+- aws-sdk v2/v3 client spans in the lambda context (parenting under
+  `aws.lambda`, flush before invocation end) — need real AWS services;
+  owned by L3.
+- durable-execution checkpoint extraction — owned by
+  `serverless-e2e-tests/durable-functions`.

--- a/integration_tests_local/run.sh
+++ b/integration_tests_local/run.sh
@@ -22,10 +22,14 @@
 # manual-status-500        | cjs   | status-code-500s.handle                  | manual wrap; API GW 500 -> span error + enhanced error metric
 # manual-send-metrics      | cjs   | send-metrics.handle                      | manual wrap; sendDistributionMetric via DD_FLUSH_TO_LOG
 # manual-process-input     | cjs   | process-input.handle                     | manual wrap; dd-trace child spans via tracer.wrap
+# manual-callback          | cjs   | callback.handle                          | manual wrap; callback-style (event, context, callback) handler — the spike's proven break seam
 # cjs-http-requests       | cjs   | node_modules/datadog-lambda-js/dist/handler.handler | npm redirect; downstream HTTP header injection via dd-trace's http plugin (hermetic mock server)
 # manual-http-requests    | cjs   | http-requests-manual.handle              | manual wrap; patchHttp fallback wrapping + per-request logging (hermetic mock)
+# cjs-fetch-requests      | cjs   | node_modules/datadog-lambda-js/dist/handler.handler | npm redirect; header injection on global fetch via dd-trace's undici plugin (hermetic mock)
 # cjs-custom-extractor     | cjs   | node_modules/datadog-lambda-js/dist/handler.handler | DD_TRACE_EXTRACTOR custom extractor + _dd.parent_source
 # cjs-proactive-init       | cjs   | node_modules/datadog-lambda-js/dist/handler.handler | proactive-initialization markers (raw-log assertions)
+# manual-metrics-only      | cjs   | send-metrics.handle                      | DD_TRACE_ENABLED=false: metrics flush, no spans, no log correlation
+# cjs-capture-payload      | cjs   | node_modules/datadog-lambda-js/dist/handler.handler | DD_CAPTURE_LAMBDA_PAYLOAD=true: function.request/response span tags
 #
 # Usage (from repo root or this directory):
 #   ./integration_tests_local/run.sh                 # all runtimes, all cases
@@ -111,10 +115,14 @@ ALL_CASES=(
     "manual-status-500"
     "manual-send-metrics"
     "manual-process-input"
+    "manual-callback"
     "cjs-http-requests"
     "manual-http-requests"
+    "cjs-fetch-requests"
     "cjs-custom-extractor"
     "cjs-proactive-init"
+    "manual-metrics-only"
+    "cjs-capture-payload"
 )
 
 function configure_case() {
@@ -184,6 +192,37 @@ function configure_case() {
             case_entry_handler="process-input.handle"
             case_return_mode=per-event
             ;;
+        manual-callback)
+            # Callback-style (event, context, callback) handler under manual
+            # wrap — the seam the migration spike broke (the tracePromise
+            # wrapper replaced promisifiedHandler's call site, so callback
+            # handlers returned null to API Gateway). handler.spec.ts pins
+            # the unit behavior; this case pins the same path end to end
+            # through the RIE invoke.
+            case_image=cjs
+            case_entry_handler="callback.handle"
+            ;;
+        manual-metrics-only)
+            # DD_TRACE_ENABLED=false — metrics-only customers. The golden pins
+            # that enhanced + custom metrics still flush (via DD_FLUSH_TO_LOG)
+            # while no aws.lambda span, no trace JSON and no dd.trace_id log
+            # correlation appear. Same handler and per-event payloads as
+            # manual-send-metrics; the diff between the two goldens is exactly
+            # the tracing surface.
+            case_image=cjs
+            case_entry_handler="send-metrics.handle"
+            case_extra_env=(-e DD_TRACE_ENABLED=false)
+            case_return_mode=per-event
+            ;;
+        cjs-capture-payload)
+            # DD_CAPTURE_LAMBDA_PAYLOAD=true — the aws.lambda span meta gains
+            # function.request / function.response holding the captured
+            # payloads (event JSON is static, so the captured tags are
+            # deterministic).
+            case_image=cjs
+            case_entry_handler="node_modules/datadog-lambda-js/dist/handler.handler"
+            case_extra_env=(-e DD_LAMBDA_HANDLER=handler.handle -e DD_CAPTURE_LAMBDA_PAYLOAD=true)
+            ;;
         cjs-http-requests)
             # Redirect mode, not manual wrap: redirect mode initializes
             # dd-trace before the user handler loads, so the tracer's http
@@ -218,6 +257,18 @@ function configure_case() {
             case_entry_handler="http-requests-manual.handle"
             case_needs_mock=true
             case_extra_env=(-e "MOCK_HTTP_URLS=http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu")
+            ;;
+        cjs-fetch-requests)
+            # fetch/undici variant of cjs-http-requests: on Node 18+ the
+            # global fetch is undici, instrumented by dd-trace's undici
+            # plugin — a different injection path than the http/https plugin
+            # that patches axios. Redirect mode, so dd-trace initializes
+            # before the user handler loads and the plugin does the
+            # injection; the mock echo pins the injected headers.
+            case_image=cjs
+            case_entry_handler="node_modules/datadog-lambda-js/dist/handler.handler"
+            case_needs_mock=true
+            case_extra_env=(-e DD_LAMBDA_HANDLER=fetch-requests.handle -e "MOCK_HTTP_URLS=http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu")
             ;;
         cjs-custom-extractor)
             case_image=cjs

--- a/integration_tests_local/snapshots/logs/cjs-capture-payload.log
+++ b/integration_tests_local/snapshots/logs/cjs-capture-payload.log
@@ -1,0 +1,1160 @@
+XXXX [INFO] (rapid) exec '/lambda-entrypoint.sh' (cwd=/var/task, handler=node_modules/datadog-lambda-js/dist/handler.handler)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INIT START(type: on-demand, phase: init)
+XXXX [INFO] (rapid) The extension's directory "/opt/extensions" does not exist, assuming no extensions to be loaded.
+XXXX [INFO] (rapid) Starting runtime without AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN , Expected?: false
+XXXX [INFO] (rapid) INIT RTDONE(status: success)
+XXXX [INFO] (rapid) INIT REPORT(durationMs: XXXX)
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:true",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.apigateway",
+        "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedApiGatewayServiceName",
+          "runtime-id":"XXXX",
+          "http.url": "https://undefined",
+          "resource_names": "GET /{proxy+}",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "apiid":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "sync",
+          "http.method": "GET",
+          "stage": "test",
+          "domain_name": "",
+          "dd_resource_key": "arn:aws:apigateway:us-east-1::/restapis/wt6mne2s9k",
+          "http.status_code": "200",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "true",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "arn:aws:apigateway:us-east-1::/restapis/wt6mne2s9k/stages/test",
+          "http.method": "GET",
+          "http.route": "/{proxy+}",
+          "function.request.path": "/test/hello",
+          "function.request.headers.Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+          "function.request.headers.Accept-Encoding": "gzip, deflate, lzma, sdch, br",
+          "function.request.headers.Accept-Language": "en-US,en;q=0.8",
+          "function.request.headers.CloudFront-Forwarded-Proto": "https",
+          "function.request.headers.CloudFront-Is-Desktop-Viewer": "true",
+          "function.request.headers.CloudFront-Is-Mobile-Viewer": "false",
+          "function.request.headers.CloudFront-Is-SmartTV-Viewer": "false",
+          "function.request.headers.CloudFront-Is-Tablet-Viewer": "false",
+          "function.request.headers.CloudFront-Viewer-Country": "US",
+          "function.request.headers.Host": "wt6mne2s9k.execute-api.us-west-2.amazonaws.com",
+          "function.request.headers.Upgrade-Insecure-Requests": "1",
+          "function.request.headers.User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+          "function.request.headers.Via": "1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)",
+          "function.request.headers.X-Amz-Cf-Id": "nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g==",
+          "function.request.headers.X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+          "function.request.headers.X-Forwarded-Port": "443",
+          "function.request.headers.X-Forwarded-Proto": "https",
+          "function.request.pathParameters.proxy": "hello",
+          "function.request.requestContext.accountId": "123456789012",
+          "function.request.requestContext.resourceId": "us4z18",
+          "function.request.requestContext.stage": "test",
+          "function.request.requestContext.requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+          "function.request.requestContext.identity.cognitoIdentityPoolId": "",
+          "function.request.requestContext.identity.accountId": "",
+          "function.request.requestContext.identity.cognitoIdentityId": "",
+          "function.request.requestContext.identity.caller": "",
+          "function.request.requestContext.identity.apiKey": "",
+          "function.request.requestContext.identity.sourceIp": "192.168.100.1",
+          "function.request.requestContext.identity.cognitoAuthenticationType": "",
+          "function.request.requestContext.identity.cognitoAuthenticationProvider": "",
+          "function.request.requestContext.identity.userArn": "",
+          "function.request.requestContext.identity.userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+          "function.request.requestContext.identity.user": "",
+          "function.request.requestContext.resourcePath": "/{proxy+}",
+          "function.request.requestContext.httpMethod": "GET",
+          "function.request.requestContext.apiId": "wt6mne2s9k",
+          "function.request.resource": "/{proxy+}",
+          "function.request.httpMethod": "GET",
+          "function.request.queryStringParameters.name": "me",
+          "function.request.stageVariables.stageVarName": "stageVarValue",
+          "function.response.message": "hello, dog!",
+          "http.status_code": "200",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Init Duration: XXXX ms	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "MODIFY someTableName",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "MODIFY",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "function.request.Records.0.eventID": "0123456789abcdef09123456789abcdef",
+          "function.request.Records.0.eventName": "MODIFY",
+          "function.request.Records.0.eventVersion": "1.1",
+          "function.request.Records.0.eventSource": "aws:dynamodb",
+          "function.request.Records.0.awsRegion": "us-east-1",
+          "function.request.Records.0.dynamodb.ApproximateCreationDateTime": "1734555118",
+          "function.request.Records.0.dynamodb.Keys.someKeyColumnName.S": "someValue",
+          "function.request.Records.0.dynamodb.SequenceNumber": "1.2345678901234568e+26",
+          "function.request.Records.0.dynamodb.SizeBytes": "37",
+          "function.request.Records.0.dynamodb.StreamViewType": "KEYS_ONLY",
+          "function.request.Records.0.eventSourceARN": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "REMOVE someTableName",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "REMOVE",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "function.request.Records.0.eventID": "0123456789abcdef09123456789abcdef",
+          "function.request.Records.0.eventName": "REMOVE",
+          "function.request.Records.0.eventVersion": "1.1",
+          "function.request.Records.0.eventSource": "aws:dynamodb",
+          "function.request.Records.0.awsRegion": "us-east-1",
+          "function.request.Records.0.dynamodb.ApproximateCreationDateTime": "1734555118",
+          "function.request.Records.0.dynamodb.Keys.someKeyColumnName.S": "someValue",
+          "function.request.Records.0.dynamodb.SequenceNumber": "1.2345678901234568e+26",
+          "function.request.Records.0.dynamodb.SizeBytes": "37",
+          "function.request.Records.0.dynamodb.StreamViewType": "KEYS_ONLY",
+          "function.request.Records.0.eventSourceARN": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "INSERT someTableName",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "function.request.Records.0.eventID": "0123456789abcdef09123456789abcdef",
+          "function.request.Records.0.eventName": "INSERT",
+          "function.request.Records.0.eventVersion": "1.1",
+          "function.request.Records.0.eventSource": "aws:dynamodb",
+          "function.request.Records.0.awsRegion": "us-east-1",
+          "function.request.Records.0.dynamodb.ApproximateCreationDateTime": "1734555118",
+          "function.request.Records.0.dynamodb.Keys.someKeyColumnName.S": "someValue",
+          "function.request.Records.0.dynamodb.Keys.anotherKeyColumnName.S": "anotherValue",
+          "function.request.Records.0.dynamodb.SequenceNumber": "1.2345678901234568e+26",
+          "function.request.Records.0.dynamodb.SizeBytes": "37",
+          "function.request.Records.0.dynamodb.StreamViewType": "KEYS_ONLY",
+          "function.request.Records.0.eventSourceARN": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:CompleteMultipartUpload",
+          "object_key": "multipart_object.txt",
+          "object_etag": "09876543210987654321098765432109-2",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "object_size": 8388608,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "function.request.Records.0.eventVersion": "2.1",
+          "function.request.Records.0.eventSource": "aws:s3",
+          "function.request.Records.0.awsRegion": "us-east-1",
+          "function.request.Records.0.eventTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
+          "function.request.Records.0.eventName": "ObjectCreated:CompleteMultipartUpload",
+          "function.request.Records.0.userIdentity.principalId": "AWS:ABCDEFGHIJKLMNOPQRSTU:my-upstream-function",
+          "function.request.Records.0.requestParameters.sourceIPAddress": "1.234.56.78",
+          "function.request.Records.0.responseElements.x-amz-request-id": "V1234567890ABCDE",
+          "function.request.Records.0.responseElements.x-amz-id-2": "ABCDEFGHI+abcdefghijklmn/1234567890+1234567890=",
+          "function.request.Records.0.s3.s3SchemaVersion": "1",
+          "function.request.Records.0.s3.configurationId": "abcde-1234-5678-9012-abcde1234567890",
+          "function.request.Records.0.s3.bucket.name": "my-bucket-name",
+          "function.request.Records.0.s3.bucket.ownerIdentity.principalId": "ABCDEFGHIJKLMN",
+          "function.request.Records.0.s3.bucket.arn": "arn:aws:s3:::my-bucket-name",
+          "function.request.Records.0.s3.object.key": "multipart_object.txt",
+          "function.request.Records.0.s3.object.size": "8388608",
+          "function.request.Records.0.s3.object.eTag": "09876543210987654321098765432109-2",
+          "function.request.Records.0.s3.object.versionId": "r_qtaksdfj9127489Uaksdfj",
+          "function.request.Records.0.s3.object.sequencer": "00112233445566AABB",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Copy",
+          "object_key": "copied_object.txt",
+          "object_etag": "01234567890123456789012345678901",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "function.request.Records.0.eventVersion": "2.1",
+          "function.request.Records.0.eventSource": "aws:s3",
+          "function.request.Records.0.awsRegion": "us-east-1",
+          "function.request.Records.0.eventTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
+          "function.request.Records.0.eventName": "ObjectCreated:Copy",
+          "function.request.Records.0.userIdentity.principalId": "AWS:ABCDEFGHIJKLMNOPQRSTU:my-upstream-function",
+          "function.request.Records.0.requestParameters.sourceIPAddress": "1.234.56.78",
+          "function.request.Records.0.responseElements.x-amz-request-id": "V1234567890ABCDE",
+          "function.request.Records.0.responseElements.x-amz-id-2": "ABCDEFGHI+abcdefghijklmn/1234567890+1234567890=",
+          "function.request.Records.0.s3.s3SchemaVersion": "1",
+          "function.request.Records.0.s3.configurationId": "abcde-1234-5678-9012-abcde1234567890",
+          "function.request.Records.0.s3.bucket.name": "my-bucket-name",
+          "function.request.Records.0.s3.bucket.ownerIdentity.principalId": "ABCDEFGHIJKLMN",
+          "function.request.Records.0.s3.bucket.arn": "arn:aws:s3:::my-bucket-name",
+          "function.request.Records.0.s3.object.key": "copied_object.txt",
+          "function.request.Records.0.s3.object.size": "100",
+          "function.request.Records.0.s3.object.eTag": "01234567890123456789012345678901",
+          "function.request.Records.0.s3.object.versionId": "r_qtaksdfj9127489Uaksdfj",
+          "function.request.Records.0.s3.object.sequencer": "00112233445566AABB",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Put",
+          "object_key": "test_object.txt",
+          "object_etag": "abcdef0123456789abcdef01234567890",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "function.request.Records.0.eventVersion": "2.1",
+          "function.request.Records.0.eventSource": "aws:s3",
+          "function.request.Records.0.awsRegion": "us-east-1",
+          "function.request.Records.0.eventTime": "XXXX-XX-XXTXX:XX:XX.XXXZ",
+          "function.request.Records.0.eventName": "ObjectCreated:Put",
+          "function.request.Records.0.userIdentity.principalId": "AWS:ABCDEFGHIJKLMNOPQRSTU:my-upstream-function",
+          "function.request.Records.0.requestParameters.sourceIPAddress": "1.234.56.78",
+          "function.request.Records.0.responseElements.x-amz-request-id": "V1234567890ABCDE",
+          "function.request.Records.0.responseElements.x-amz-id-2": "ABCDEFGHI+abcdefghijklmn/1234567890+1234567890=",
+          "function.request.Records.0.s3.s3SchemaVersion": "1",
+          "function.request.Records.0.s3.configurationId": "abcde-1234-5678-9012-abcde1234567890",
+          "function.request.Records.0.s3.bucket.name": "my-bucket-name",
+          "function.request.Records.0.s3.bucket.ownerIdentity.principalId": "ABCDEFGHIJKLMN",
+          "function.request.Records.0.s3.bucket.arn": "arn:aws:s3:::my-bucket-name",
+          "function.request.Records.0.s3.object.key": "test_object.txt",
+          "function.request.Records.0.s3.object.size": "100",
+          "function.request.Records.0.s3.object.eTag": "abcdef0123456789abcdef01234567890",
+          "function.request.Records.0.s3.object.versionId": "r_qtaksdfj9127489Uaksdfj",
+          "function.request.Records.0.s3.object.sequencer": "00112233445566AABB",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sns",
+        "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
+        "error": 0,
+        "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSnsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "message_id": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "function.request.Records.0.EventVersion": "1",
+          "function.request.Records.0.EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "function.request.Records.0.EventSource": "aws:sns",
+          "function.request.Records.0.Sns.SignatureVersion": "1",
+          "function.request.Records.0.Sns.Timestamp": "XXXX-XX-XXTXX:XX:XX.XXXZ",
+          "function.request.Records.0.Sns.Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
+          "function.request.Records.0.Sns.SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+          "function.request.Records.0.Sns.MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+          "function.request.Records.0.Sns.Message": "Hello from SNS!",
+          "function.request.Records.0.Sns.MessageAttributes.Test.Type": "String",
+          "function.request.Records.0.Sns.MessageAttributes.Test.Value": "TestString",
+          "function.request.Records.0.Sns.MessageAttributes.TestBinary.Type": "Binary",
+          "function.request.Records.0.Sns.MessageAttributes.TestBinary.Value": "TestBinary",
+          "function.request.Records.0.Sns.Type": "Notification",
+          "function.request.Records.0.Sns.UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "function.request.Records.0.Sns.TopicArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "function.request.Records.0.Sns.Subject": "TestInvoke",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-capture-payload",
+    "resource:integration-tests-js-local-cjs-capture-payload",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sqs",
+        "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-capture-payload",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSqsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-capture-payload",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "retry_count": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-capture-payload",
+        "service": "integration-tests-js-local-cjs-capture-payload",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-capture-payload",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-capture-payload",
+          "functionname": "integration-tests-js-local-cjs-capture-payload",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "function.request.Records.0.messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+          "function.request.Records.0.receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "function.request.Records.0.body": "Test message.",
+          "function.request.Records.0.attributes.ApproximateReceiveCount": "1",
+          "function.request.Records.0.attributes.SentTimestamp": "1545082649183",
+          "function.request.Records.0.attributes.SenderId": "AIDAIENQZJOLO23YVJ4VO",
+          "function.request.Records.0.attributes.ApproximateFirstReceiveTimestamp": "1545082649185",
+          "function.request.Records.0.md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+          "function.request.Records.0.eventSource": "aws:sqs",
+          "function.request.Records.0.eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "function.request.Records.0.awsRegion": "us-east-2",
+          "function.request.Records.1.messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
+          "function.request.Records.1.receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+          "function.request.Records.1.body": "Test message.",
+          "function.request.Records.1.attributes.ApproximateReceiveCount": "1",
+          "function.request.Records.1.attributes.SentTimestamp": "1545082650636",
+          "function.request.Records.1.attributes.SenderId": "AIDAIENQZJOLO23YVJ4VO",
+          "function.request.Records.1.attributes.ApproximateFirstReceiveTimestamp": "1545082650649",
+          "function.request.Records.1.md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+          "function.request.Records.1.eventSource": "aws:sqs",
+          "function.request.Records.1.eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "function.request.Records.1.awsRegion": "us-east-2",
+          "function.response.message": "hello, dog!",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)

--- a/integration_tests_local/snapshots/logs/cjs-fetch-requests.log
+++ b/integration_tests_local/snapshots/logs/cjs-fetch-requests.log
@@ -1,0 +1,1682 @@
+XXXX [INFO] (rapid) exec '/lambda-entrypoint.sh' (cwd=/var/task, handler=node_modules/datadog-lambda-js/dist/handler.handler)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INIT START(type: on-demand, phase: init)
+XXXX [INFO] (rapid) The extension's directory "/opt/extensions" does not exist, assuming no extensions to be loaded.
+XXXX [INFO] (rapid) Starting runtime without AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN , Expected?: false
+XXXX [INFO] (rapid) INIT RTDONE(status: success)
+XXXX [INFO] (rapid) INIT REPORT(durationMs: XXXX)
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:true",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.apigateway",
+        "resource": "GET /{proxy+}",
+        "service": "remappedApiGatewayServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedApiGatewayServiceName",
+          "runtime-id":"XXXX",
+          "http.url": "https://undefined",
+          "resource_names": "GET /{proxy+}",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "apiid":"XXXX",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "sync",
+          "http.method": "GET",
+          "stage": "test",
+          "domain_name": "",
+          "dd_resource_key": "arn:aws:apigateway:us-east-1::/restapis/wt6mne2s9k",
+          "http.status_code": "200",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "true",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "arn:aws:apigateway:us-east-1::/restapis/wt6mne2s9k/stages/test",
+          "http.method": "GET",
+          "http.route": "/{proxy+}",
+          "http.status_code": "200",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Init Duration: XXXX ms	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "MODIFY someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "MODIFY someTableName",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "MODIFY",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "REMOVE someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"a23821b540813527937fbe833d70a005\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "REMOVE someTableName",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "REMOVE",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.dynamodb",
+        "resource": "INSERT someTableName",
+        "service": "remappedDynamoDbServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.dynamodb.item\",\"ptr.dir\":\"u\",\"ptr.hash\":\"843472b4a65c45fcc3f14939c6cae6d1\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedDynamoDbServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.dynamodb",
+          "tablename": "someTableName",
+          "resource_names": "INSERT someTableName",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "event_id": "0123456789abcdef09123456789abcdef",
+          "stream_view_type": "KEYS_ONLY",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "size_bytes": 37,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "arn:aws:dynamodb:us-east-1:1234567890:table/someTableName/stream/2024-12-11T20:00:00.000",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"5e945cd2009d743bdef019835b237969\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:CompleteMultipartUpload",
+          "object_key": "multipart_object.txt",
+          "object_etag": "09876543210987654321098765432109-2",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "object_size": 8388608,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"9b03fa9d6a34c7b40a2a2907eb0db1f6\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Copy",
+          "object_key": "copied_object.txt",
+          "object_etag": "01234567890123456789012345678901",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.s3",
+        "resource": "my-bucket-name",
+        "service": "remappedS3ServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.span_links": "[{\"trace_id\":\"00000000000000000000000000000000\",\"span_id\":\"0000000000000000\",\"attributes\":{\"ptr.kind\":\"aws.s3.object\",\"ptr.dir\":\"u\",\"ptr.hash\":\"b2229b8289f3e49de4f01af8d228ebd8\",\"link.kind\":\"span-pointer\"}}]",
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedS3ServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.s3",
+          "resource_names": "my-bucket-name",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "bucketname": "my-bucket-name",
+          "bucket_arn": "arn:aws:s3:::my-bucket-name",
+          "event_name": "ObjectCreated:Put",
+          "object_key": "test_object.txt",
+          "object_etag": "abcdef0123456789abcdef01234567890",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "object_size": 100,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "arn:aws:s3:::my-bucket-name",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sns",
+        "resource": "sns-lambda",
+        "service": "remappedSnsServiceName",
+        "type": "sns",
+        "error": 0,
+        "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSnsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "message_id": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "event_subscription_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-cjs-fetch-requests",
+    "resource:integration-tests-js-local-cjs-fetch-requests",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "function:fetch-request",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-us: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] mock-http saw headers for http://mock-http:8080/ip-ranges-eu: {"host":"mock-http:8080","connection":"keep-alive","x-datadog-trace-id":"XXXX","x-datadog-parent-id":"XXXX","x-datadog-sampling-priority":"1","x-datadog-tags":"_dd.p.tid=XXXX,_dd.p.dm=-0","traceparent":"XXXX","tracestate":"XXXX","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	[dd.trace_id=XXXX dd.span_id=XXXX] Snapshot test fetch requests successfully made to URLs: http://mock-http:8080/ip-ranges-us,http://mock-http:8080/ip-ranges-eu
+{
+  "traces": [
+    [
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.sqs",
+        "resource": "my-queue",
+        "service": "remappedSqsServiceName",
+        "type": "web",
+        "error": 0,
+        "meta": {
+          "_dd.tags.process": "entrypoint.type:script,entrypoint.workdir:task,package.json.name:container-cjs-test,svc.auto:integration-tests-js-local-cjs-fetch-requests",
+          "_dd.p.tid": "XXXX",
+          "_dd.p.dm": "-0",
+          "_dd.origin": "lambda",
+          "service": "remappedSqsServiceName",
+          "runtime-id":"XXXX",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "request_id":"XXXX",
+          "span.kind": "server",
+          "_inferred_span.tag_source": "self",
+          "_inferred_span.synchronicity": "async",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_dd.integration": "opentracing",
+          "_dd.svc_src": "m",
+          "_dd.base_service": "integration-tests-js-local-cjs-fetch-requests",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_dd.measured": 1,
+          "retry_count": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "aws.lambda",
+        "resource": "integration-tests-js-local-cjs-fetch-requests",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "serverless",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "span.kind": "server",
+          "cold_start": "false",
+          "function_arn":"XXXX",
+          "function_version": "$LATEST",
+          "request_id":"XXXX",
+          "resource_names": "integration-tests-js-local-cjs-fetch-requests",
+          "functionname": "integration-tests-js-local-cjs-fetch-requests",
+          "datadog_lambda":"XXXX",
+          "dd_trace": "",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+          "_dd.integration": "opentracing",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-us",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      },
+      {
+        "trace_id":"XXXX",
+        "span_id":"XXXX",
+        "parent_id":"XXXX",
+        "name": "http.request",
+        "resource": "GET",
+        "service": "integration-tests-js-local-cjs-fetch-requests",
+        "type": "http",
+        "error": 0,
+        "meta": {
+          "_dd.origin": "lambda",
+          "version": "1.0.0",
+          "service": "integration-tests-js-local-cjs-fetch-requests",
+          "runtime-id":"XXXX",
+          "component": "fetch",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "http://mock-http:8080/ip-ranges-eu",
+          "out.host": "mock-http",
+          "http.status_code": "200",
+          "_dd.integration": "fetch",
+          "language": "javascript"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "network.destination.port": 8080,
+          "process_id":XXXX,
+          "_sampling_priority_v1": 1
+        },
+        "start":XXXX,
+        "duration":XXXX,
+        "links": []
+      }
+    ]
+  ]
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB

--- a/integration_tests_local/snapshots/logs/manual-callback.log
+++ b/integration_tests_local/snapshots/logs/manual-callback.log
@@ -1,0 +1,186 @@
+XXXX [INFO] (rapid) exec '/lambda-entrypoint.sh' (cwd=/var/task, handler=callback.handle)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INIT START(type: on-demand, phase: init)
+XXXX [INFO] (rapid) The extension's directory "/opt/extensions" does not exist, assuming no extensions to be loaded.
+XXXX [INFO] (rapid) Starting runtime without AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN , Expected?: false
+XXXX [INFO] (rapid) INIT RTDONE(status: success)
+XXXX [INFO] (rapid) INIT REPORT(durationMs: XXXX)
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:true",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Init Duration: XXXX ms	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-callback",
+    "resource:integration-tests-js-local-manual-callback",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB

--- a/integration_tests_local/snapshots/logs/manual-metrics-only.log
+++ b/integration_tests_local/snapshots/logs/manual-metrics-only.log
@@ -1,0 +1,325 @@
+XXXX [INFO] (rapid) exec '/lambda-entrypoint.sh' (cwd=/var/task, handler=send-metrics.handle)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INIT START(type: on-demand, phase: init)
+XXXX [INFO] (rapid) The extension's directory "/opt/extensions" does not exist, assuming no extensions to be loaded.
+XXXX [INFO] (rapid) Starting runtime without AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN , Expected?: false
+XXXX [INFO] (rapid) INIT RTDONE(status: success)
+XXXX [INFO] (rapid) INIT REPORT(durationMs: XXXX)
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:true",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.outside_handler",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:outside_handler",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:APIGateway",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed APIGateway request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Init Duration: XXXX ms	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:undefined",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed undefined request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:undefined",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed undefined request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:undefined",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed undefined request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:undefined",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed undefined request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:undefined",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed undefined request
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:undefined",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed undefined request
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+START RequestId: XXXX Version: $LATEST
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.records_processed",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:SNS",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:SNS",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed SNS request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB
+XXXX [INFO] (rapid) INVOKE START(requestId: XXXX)
+START RequestId: XXXX Version: $LATEST
+{
+  "e": XXXX,
+  "m": "aws.lambda.enhanced.invocations",
+  "t": [
+    "region:us-east-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-js-local-manual-metrics-only",
+    "resource:integration-tests-js-local-manual-metrics-only",
+    "memorysize:3008",
+    "cold_start:false",
+    "datadog_lambda:vX.X.X",
+    "runtime:nodejsXX.x"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.records_processed",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:SQS",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.records_processed",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:SQS",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+{
+  "e": XXXX,
+  "m": "serverless.integration_test.execution",
+  "t": [
+    "tagkey:tagvalue",
+    "eventsource:SQS",
+    "dd_lambda_layer:datadog-nodevXX.XX.X"
+  ],
+  "v": 1
+}
+XXXX-XX-XXTXX:XX:XX.XXXZ	XXXX-XXXX-XXXX-XXXX-XXXX	INFO	Processed SQS request
+XXXX [INFO] (rapid) INVOKE RTDONE(status: success, produced bytes: 0, duration: XXXXms)
+END RequestId: XXXX
+REPORT RequestId: XXXX	Duration: XXXX ms	Billed Duration: XXXX ms	Memory Size: 3008 MB	Max Memory Used: XXXX MB

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_api-gateway-get.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_api-gateway-get.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","eventType":"APIGateway","requestId":"41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9"}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_dynamodb-one-key-table.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_dynamodb-one-key-table.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":[]}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_dynamodb-remove.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_dynamodb-remove.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":[]}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_dynamodb-two-key-table.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_dynamodb-two-key-table.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":[]}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_s3-completemultipartupload.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_s3-completemultipartupload.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":[]}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_s3-copyobject.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_s3-copyobject.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":[]}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_s3-putobject.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_s3-putobject.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":[]}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_sns.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_sns.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":["95df01b4-ee98-5cb9-9903-4c221d41eb5e"],"eventType":"SNS"}

--- a/integration_tests_local/snapshots/return_values/manual-metrics-only_sqs.json
+++ b/integration_tests_local/snapshots/return_values/manual-metrics-only_sqs.json
@@ -1,0 +1,1 @@
+{"message":"hello, dog!","recordIds":["059f36b4-87a3-44ab-83d2-661975830a7d","2e1424d4-f796-459a-8184-9c92662be6da"],"eventType":"SQS"}

--- a/migration_parity.md
+++ b/migration_parity.md
@@ -89,7 +89,7 @@ no promises/`async` in npm production code). Everything else migrates.
 | Feature | Owner (code location) | Test type/location | Test implementation | Migration status | Effect in layer |
 |---|---|---|---|---|---|
 | promise handler | dd:`lambda.js` `wrap` → instrumentation channel | L1 + L2 | `dl:src/utils/handler.spec.ts` → port + golden | pending | dd-trace |
-| callback handler (no early completion) | dd:`packages/datadog-plugin-lambda/src/handler-utils.js` (`promisifiedHandler`) | L1 + L2 | `dl:src/utils/handler.spec.ts` → port + golden; first test pins the `tracePromise` non-thenable behavior empirically | pending | dd-trace |
+| callback handler (no early completion) | dd:`packages/datadog-plugin-lambda/src/handler-utils.js` (`promisifiedHandler`) | L1 + L2 | `dl:src/utils/handler.spec.ts` → port + golden `manual-callback`; first test pins the `tracePromise` non-thenable behavior empirically | pending | dd-trace |
 | sync handler | dd:`lambda.js` `wrap` path | L1 + L2 | same spec + golden | pending | dd-trace |
 | callback/promise race (first wins) | dd:`handler-utils.js` | L1 | `dl:src/utils/handler.spec.ts` race cases → port | pending | dd-trace |
 | `context.done/succeed/fail` | dd:`handler-utils.js` | L1 | same spec → port | pending | dd-trace |
@@ -163,7 +163,7 @@ fallback (unconditional; sampling-priority gated on `mergeXrayTraces` — docume
 | `_dd.parent_source` | dd:`…/src/index.js` | L2 or L3 | — new fixture, else e2e-assigned | pending | dd-trace |
 | `proactive_initialization` | dd:`…/src/cold-start.js` | L3 only (RIE cannot produce it; normalization drops markers) | e2e — assigned to `lambda-features` | pending | dd-trace |
 | HTTP 5xx → span error + enhanced error metric | dd:`…/src/index.js` + `enhanced-metrics.js` | L1 + L2 | golden 500 fixture + unit | pending | dd-trace |
-| payload capture + depth cap | dd:`…/src/handler-utils.js` (`tagObject`) | L1 + L2 | `dl:src/utils/tag-object.spec.ts` → port + golden toggle fixture | pending | dd-trace |
+| payload capture + depth cap | dd:`…/src/handler-utils.js` (`tagObject`) | L1 + L2 | `dl:src/utils/tag-object.spec.ts` → port + golden `cjs-capture-payload` (toggle on; default-off path pinned by every other golden) | pending | dd-trace |
 | log injection (trace ids in console output) | dd:`…/src/console-patcher.js` | L1 + L2 | `dl:src/trace/patch-console.spec.ts` → port + golden | pending | dd-trace |
 
 ## Span pointers
@@ -212,6 +212,8 @@ conditional on the extension being present.
 | Feature | Owner (code location) | Test type/location | Test implementation | Migration status | Effect in layer |
 |---|---|---|---|---|---|
 | HTTP header injection (`patch-http.ts`) | dd-core: dd-trace http/https plugins | L2 | golden (downstream headers visible in fixtures) | dd-core | dd-trace |
+| fetch/undici header injection | dd-core: dd-trace undici plugin | L2 | golden `cjs-fetch-requests` (mock echo of injected headers) | dd-core | dd-trace |
+| Lambda profiling (`DD_PROFILING_ENABLED`, layer ≥87) | dd-core: dd-trace profiler (`@datadog/pprof`) — never lived in this repo's business logic | L1 (dd-trace-js profiler suites) + L3 `lambda-features` Profiling row | existing dd-trace profiler tests; prune-list mapping review covers the native footprint | dd-core | dd-trace |
 | tracer wrapper / span wrapper plumbing | dd-core: dd-trace tracer API | — | covered transitively by plugin tests | dd-core | dd-trace |
 
 ## Release and packaging


### PR DESCRIPTION
## What this is

PR 2b of the dd-trace migration roadmap (Phase 0). [PR 2a](https://github.com/DataDog/datadog-lambda-js/pull/821) brought the local RIE harness to
coverage parity with the old AWS suite; this PR goes **beyond** the old suite, adding the
first four customer usage modes that have zero end-to-end coverage on any surface — L1
specs cover the units, but nothing pins these paths through a real invocation.

It moves no library code. Fixtures, case registrations, docs, and goldens only — all
goldens captured from the current pre-migration implementation.

Base: this branches off `joey/l2-coverage-parity` ([PR 2a](https://github.com/DataDog/datadog-lambda-js/pull/821)) and should land after it.

## The four cases

| Case | What it pins | Why it matters |
|---|---|---|
| `manual-callback` | Callback-style `(event, context, callback)` handler under manual `datadog()` wrap, through the RIE invoke (async completion via `setTimeout`, so the wrapper can't mistake it for a sync return) | The migration spike broke **exactly this seam**: the new host's `tracePromise` wrapper replaced `promisifiedHandler`'s call site, and callback handlers returned `null` to API Gateway. `handler.spec.ts` pins the units; until now nothing pinned it end to end |
| `cjs-fetch-requests` | Global `fetch` outbound in redirect mode; mock echo shows the injected `x-datadog-*` headers (18/18 requests carry all four) | On Node 18+ `fetch` is undici, instrumented by dd-trace's **undici** plugin — a different injection path than the http/https plugin that `cjs-http-requests` pins via axios. Main-path pattern for Node 18+ customers |
| `manual-metrics-only` | `DD_TRACE_ENABLED=false`: enhanced + custom metrics still flush (via `DD_FLUSH_TO_LOG`), and **no** `aws.lambda` span, **no** trace JSON, **no** `dd.trace_id` log correlation | The metrics-only customer configuration — real and non-rare — had no end-to-end coverage. Return-value goldens are byte-identical to `manual-send-metrics` (verified), so the toggle is pinned to change *only* the tracing surface |
| `cjs-capture-payload` | `DD_CAPTURE_LAMBDA_PAYLOAD=true` in redirect mode: `function.request` / `function.response` span tags holding the captured payloads | Documented feature with no golden; the config-wiring phase is exactly where payload capture could drift invisibly |

## Docs and ledger

- Harness README: case-table entries for the four cases, plus a **"deliberately not
  covered locally"** list in the emulation-gaps section — response streaming /
  `time_to_first_byte`, direct-API and KMS/Secrets metric paths, aws-sdk client spans,
  durable execution — each with its owning suite, so the scoping discussion doesn't recur.
- `migration_parity.md`: the callback and payload-capture rows now point at the new
  goldens; new dd-core ownership rows for fetch/undici injection and **Lambda profiling**
  (`DD_PROFILING_ENABLED` is a documented, shipped feature that had no ledger row — the
  capability lives in dd-trace's profiler, covered by its suites plus the L3 Profiling
  row).

## Verification

All four cases green in strict compare mode on the node22 and node18 legs against shared
goldens — no per-runtime overrides needed. `manual-callback` additionally verified on the
node26 preview leg (newest RIC + callback style was the riskiest combination). The CI
workflow runs every case per runtime leg by default, so no workflow change is needed;
expect 16 cases × 5 runtimes = 80 legs after this lands on top of PR 2a.

Remaining PR 2b items (not in this PR): kinesis/eventbridge/sns-sqs event goldens,
negative-toggle variants (`DD_ENHANCED_METRICS=false` / `DD_LOGS_INJECTION=false`), and an
authorizer encode/decode fixture.

## Trying it locally

```bash
RUNTIME_PARAM=22 CASE_PARAM=manual-callback ./integration_tests_local/run.sh
RUNTIME_PARAM=18 CASE_PARAM=cjs-fetch-requests ./integration_tests_local/run.sh
RUNTIME_PARAM=22 CASE_PARAM=manual-metrics-only ./integration_tests_local/run.sh
RUNTIME_PARAM=22 CASE_PARAM=cjs-capture-payload ./integration_tests_local/run.sh
```
