### PR TITLE
fix(deps): pin import-in-the-middle to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@aws-sdk/types": "3.965.0",
     "@aws-sdk/util-locate-window": "3.965.0",
     "fast-xml-parser": "^4.5.7",
+    "import-in-the-middle": "3.4.0",
     "uuid": "^8.3.2",
     "js-yaml": "^3.15.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@ ieee754@^1.1.4:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-import-in-the-middle@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz#af7dacd4f3c25826abfc8314ebc71b6dcf47e238"
-  integrity sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==
+import-in-the-middle@3.4.0, import-in-the-middle@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.4.0.tgz#74d868189dddbc300c3a558743504884277038de"
+  integrity sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw==
   dependencies:
     cjs-module-lexer "^2.2.0"
     es-module-lexer "^2.2.0"


### PR DESCRIPTION
import-in-the-middle 3.5.0 breaks esbuild, so dd-trace-js pinned the dependency to 3.4.0. Mirror that pin here.

This repo has no direct dependency on the package — it arrives through dd-trace, which declares `^3.3.2` on both the v5 and v6 lines, so a `resolutions` entry is the lever. The live exposure was the daily `yarn upgrade` in .github/workflows/update-deps.yml, which would have floated the lockfile to 3.5.0 on its own.

Verified the pin survives a bare `yarn upgrade`, and that the Node 18/20 layer path (install_deps.sh, which re-resolves the v5 line without a frozen lockfile) still lands on 3.4.0.

`resolutions` only governs builds in this repo — the layer and CI. npm consumers resolve dd-trace as a peer dependency and pick up import-in-the-middle themselves.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
